### PR TITLE
Have the joined node already provide deployer-client

### DIFF
--- a/barclamps/crowbar.yml
+++ b/barclamps/crowbar.yml
@@ -165,6 +165,7 @@ roles:
     provides:
       - crowbar-installed-node
       - crowbar-managed-node
+      - deployer-client
 
 hammers:
   - name: 'ssh'


### PR DESCRIPTION
to allow the hardware components to run and do nothing.