### PR TITLE
protect from docker no network

### DIFF
--- a/BDD/features/dashboard_getready.feature
+++ b/BDD/features/dashboard_getready.feature
@@ -8,7 +8,7 @@ Feature: Dashboard GetReady
     Then I should see {bdd:crowbar.i18n.dashboard.getready.title}
       And I should see an input box "deployment" with {bdd:crowbar.i18n.dashboard.getready.default}
       And I should see an input box "range" with {bdd:crowbar.i18n.dashboard.getready.range_base}
-      And I should see an input box "conduit" with "1g1"
+      And I should see an input box "conduit" with "1g0"
       And I should see an input box "first_ip" with "10.10.10.10/24"
       And I should see an input box "last_ip" with "10.10.10.250/24"
       And I should see {lookup:dashboard_getready.name}

--- a/rails/app/controllers/dashboard_controller.rb
+++ b/rails/app/controllers/dashboard_controller.rb
@@ -149,7 +149,8 @@ class DashboardController < ApplicationController
             Rails.logger.info "Dashboard GetReady Deployment #{d.name} added node #{n.name}"
             # assign milestone for OS assignment
             ready.add_to_node_in_deployment n, d unless n.is_docker_node?
-            ready_network.add_to_node_in_deployment n, d
+            nics = n.attrib_nics.count rescue 0
+            ready_network.add_to_node_in_deployment n, d if nics > 0
           end
           # set desired OS to attribute
           Attrib.set "provisioner-target_os", n, params["dashboard"]["#{node_id}_os"], :user unless n.is_docker_node?

--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -220,7 +220,7 @@ class Barclamp < ActiveRecord::Base
       end if bc['attribs']
       # add menut item if wizard enabled
       if bc['wizard']
-        Nav.find_or_create_by(item: "wizard_"+bc_name, parent_item: 'deploy', name: bc_name.titleize+" Wizard", description: bc['barclamp']['description'], path: "barclamps/#{bc_name}/wizard", order: 5000)
+        Nav.find_or_create_by(item: "wizard_"+bc_name, parent_item: 'deploy', name: bc_name.titleize+" Wizard", description: bc['barclamp']['description'], path: "/barclamps/#{bc_name}/wizard", order: 5000)
       end
       barclamp
     end

--- a/rails/app/models/network.rb
+++ b/rails/app/models/network.rb
@@ -17,7 +17,7 @@ class Network < ActiveRecord::Base
   ADMIN_CATEGORY = "admin"
   BMC_CATEGORY   = "bmc"
   V6AUTO         = "auto"   # if this changes, update the :v6prefix validator too!
-  DEFAULTCONDUIT = '1g1'
+  DEFAULTCONDUIT = '1g0'
   BMCCONDUIT     = 'bmc'
 
   audited


### PR DESCRIPTION
fix bug found by @galthaus where no networks were present on docker containers

In that case, it still adds the network to the deployment but nodes w/o networks are not attached by default.

Also, changed the default conduit to something safer (1g0)