### PR TITLE
bug 838 - deployment roles where not editable

### DIFF
--- a/rails/app/views/node_roles/_raw.html.haml
+++ b/rails/app/views/node_roles/_raw.html.haml
@@ -2,7 +2,7 @@
   =t 'no_items'
 - else
   - obj_type = obj.class.to_s.underscore + "_id"
-  - editable = (obj.is_a? NodeRole and obj.proposed?) or obj.is_a? DeploymentRole
+  - editable = (obj.is_a? NodeRole and obj.proposed?) || (obj.is_a? DeploymentRole)
   %table.data.box
     %thead
       %tr


### PR DESCRIPTION
error was hiding the desired DeploymentRoles are always editable behavior