### PR TITLE
network name cannot be edited

### DIFF
--- a/rails/app/views/networks/index.html.haml
+++ b/rails/app/views/networks/index.html.haml
@@ -33,7 +33,7 @@
   %tfoot
     = form_for :network, :'data-remote' => true, :url => networks_path(), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
       %tr
-        %td= text_field_tag :name, t('default'), :size=>6
+        %td= t('.generated')
         %td= text_field_tag :description, "", :size=>20
         %td= text_field_tag :category, 'general', :size=>10
         %td= text_field_tag :group, 'default', :size=>10

--- a/rails/config/locales/en.yml
+++ b/rails/config/locales/en.yml
@@ -71,6 +71,7 @@ en:
   prev: "Previous"
   export: "Export"
   default: "Default"
+  generated: "[generated]"
   useradded: "Created by user '%{user}'"
   automatic: "Created Automatically by System"
   automatic_by: "Created Automatically by %{name}"

--- a/rails/config/locales/network/en.yml
+++ b/rails/config/locales/network/en.yml
@@ -66,6 +66,7 @@ en:
     index:
       title: "Installed Networks"
       add: "Add Network"
+      generated: "[category]-[group]"
       <<: *network_common
     show:
       <<: *network_common


### PR DESCRIPTION
network name is now generated from category & group.  it cannot be added then created.

PS: apparently, you COULD change the category & group as an update and that would leave the name in place.

connect to #842 