### PR TITLE
Make the provisioner an internal service frontend by the

### DIFF
--- a/chef/cookbooks/provisioner/recipes/servers.rb
+++ b/chef/cookbooks/provisioner/recipes/servers.rb
@@ -107,3 +107,10 @@ template "/etc/consul.d/rebar-provisioner.json" do
   variables(:web_port => web_port, :ip_addr => ip_addr)
   notifies :run, "bash[reload consul provisioner]", :immediately
 end
+template "/etc/consul.d/rebar-provisioner-tftp.json" do
+  source "consul-provisioner-tftp-server.json.erb"
+  mode 0644
+  owner "root"
+  variables(:web_port => web_port, :ip_addr => ip_addr)
+  notifies :run, "bash[reload consul provisioner]", :immediately
+end

--- a/chef/cookbooks/provisioner/recipes/update_nodes.rb
+++ b/chef/cookbooks/provisioner/recipes/update_nodes.rb
@@ -15,6 +15,7 @@
 
 domain_name = node['rebar']['dns']['domain']
 provisioner_web=node['rebar']['provisioner']['server']['webservers'].first["url"]
+provisioner_addr=node['rebar']['provisioner']['server']['webservers'].first["address"]
 api_server=node['rebar']['api']['servers'].first["url"]
 ntp_server="#{node['rebar']['ntp']['servers'].first}"
 tftproot = node['rebar']['provisioner']['server']['root']
@@ -75,6 +76,7 @@ new_clients = {}
                 :online => node['rebar']['provisioner']['server']['online'],
                 :domain => domain_name,
                 :provisioner_web => provisioner_web,
+                :provisioner_addr => provisioner_addr,
                 :ntp_server => ntp_server,
                 :proxy => node['rebar']['proxy']['servers'].first['url'],
                 :keys => (node['rebar']['access_keys'] rescue Hash.new).values.sort.join($/),

--- a/chef/cookbooks/provisioner/templates/default/consul-provisioner-tftp-server.json.erb
+++ b/chef/cookbooks/provisioner/templates/default/consul-provisioner-tftp-server.json.erb
@@ -1,11 +1,11 @@
 {
   "service": {
-    "name": "internal-provisioner-service",
+    "name": "internal-provisioner-tftp-service",
     "tags": [ "system" ],
     <% if @ip_addr -%>
     "address": "<%=@ip_addr%>",
     <% end -%>
-    "port": <%=@web_port%>,
+    "port": 69,
     "check": {
       "script": "pidof sws",
       "interval": "10s"

--- a/chef/cookbooks/provisioner/templates/default/control.sh.erb
+++ b/chef/cookbooks/provisioner/templates/default/control.sh.erb
@@ -24,7 +24,7 @@ cp /usr/share/zoneinfo/GMT /etc/localtime
 
 export http_proxy="<%=@proxy%>"
 export https_proxy="$http_proxy"
-export no_proxy="localhost,127.0.0.1,localaddress,.<%=@domain%>"
+export no_proxy="localhost,127.0.0.1,localaddress,.<%=@domain%>,<%=@provisioner_addr%>"
 provisioner="<%=@provisioner_web%>"
 api_server="<%=@api_server%>"
 chef_rpm=chef-11.16.4-1.el6.x86_64.rpm

--- a/rails/app/models/barclamp_provisioner/server.rb
+++ b/rails/app/models/barclamp_provisioner/server.rb
@@ -15,6 +15,11 @@
 
 class BarclampProvisioner::Server < Role
 
+  def on_todo(nr)
+    # Make sure that the provisioner is setup.
+    system("/opt/digitalrebar/core/bin/update_provisioner #{nr.node.address.addr} > /tmp/up-server.out 2>&1")
+  end
+
   def sysdata(nr)
     my_addr = nr.node.addresses(:v4_only).first
     raise "No address for the Provisioner Server" unless my_addr

--- a/rails/app/models/barclamp_provisioner/service.rb
+++ b/rails/app/models/barclamp_provisioner/service.rb
@@ -29,9 +29,6 @@ class BarclampProvisioner::Service < Service
         url << addr.addr
       end
 
-      # Make sure that the provisioner is setup.
-      system("/opt/digitalrebar/core/bin/update_provisioner #{addr.addr} > /tmp/up.out 2>&1")
-
       url << ":#{s.ServicePort}"
       { "address" => str_addr,
         "port" => "#{s.ServicePort}",

--- a/tools/da-lib.sh
+++ b/tools/da-lib.sh
@@ -16,6 +16,10 @@ if ! which docker-compose &>/dev/null; then
     exit 1
 fi
 
+# Make sure that the tftp conntrack modules are loaded
+sudo modprobe nf_conntrack_tftp
+sudo modprobe nf_nat_tftp
+
 rebar() {
     docker exec compose_rebar_api_1 rebar -E http://127.0.0.1:3000 -U rebar -P rebar1 "$@"
 }


### PR DESCRIPTION
forwarder.

Make sure we no_proxy the provisioner server

Update the provisioner server and not the service.

Also make sure that the NAT filters are on in the docker-admin script.