### PR TITLE
Add node provider support.

### DIFF
--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -379,3 +379,9 @@ attribs:
    description: 'The bootstate that the provisioner last configured the node to use'
    map: 'rebar/provisioner/active_bootstate'
    default: "unknown"
+
+providers:
+  - name: metal
+    class: MetalProvider
+    description: "Provide basic node services for bare-metal nodes."
+    auth_details: {}

--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -259,3 +259,9 @@ attribs:
     schema:
       type: str
       required: false
+
+providers:
+  - name: phantom
+    class: Provider
+    description: "Provide basic provicer services for phantom nodes."
+    auth_details: {}

--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -43,6 +43,8 @@ class NodesController < ApplicationController
               Role.find_key(params[:role_id]).nodes
             when params.has_key?(:deployment_role_id)
               DeploymentRole.find_key(params[:deployment_role_id]).nodes
+            when params.has_key?(:provider_id)
+              Provider.find_key(params[:provider_id]).nodes
             else
               Node.all
             end
@@ -195,7 +197,7 @@ class NodesController < ApplicationController
     else
       params[:deployment_id] = Deployment.find_key(params[:deployment]).id if params.has_key? :deployment
       params[:deployment_id] ||= Deployment.system
-      params[:variant] ||= "metal"
+      params[:variant] ||= "phantom"
       params[:arch] ||= "x86_64"
       params[:os_family] ||= "linux"
       params.require(:name)

--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -29,7 +29,7 @@ class ProvidersController < ApplicationController
       format.json { render api_index Provider, objs }
     end
   end
-  
+
   # API GET /api/v2/providers
   def index
     @providers = if params.has_key?(:node_id)
@@ -38,7 +38,7 @@ class ProvidersController < ApplicationController
       Provider.all
     end
     respond_to do |format|
-      format.html { } 
+      format.html { }
       format.json { render api_index Provider, @providers }
     end
   end
@@ -76,5 +76,5 @@ class ProvidersController < ApplicationController
   def destroy
     render api_delete Provider
   end
-  
+
 end

--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -1,0 +1,80 @@
+# Copyright 2015, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class ProvidersController < ApplicationController
+
+  def sample
+    render api_sample(Provider)
+  end
+
+  def match
+    attrs = Provider.attribute_names.map{|a|a.to_sym}
+    objs = []
+    ok_params = params.permit(attrs)
+    objs = Provider.where(ok_params) if !ok_params.empty?
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Provider, objs }
+    end
+  end
+  
+  # API GET /api/v2/providers
+  def index
+    @providers = if params.has_key?(:node_id)
+      Node.find_key(params[:node_id]).providers
+    else
+      Provider.all
+    end
+    respond_to do |format|
+      format.html { } 
+      format.json { render api_index Provider, @providers }
+    end
+  end
+
+  def show
+    @provider = Provider.find_key(params[:id])
+    respond_to do |format|
+      format.html {  }
+      format.json { render api_show @provider }
+    end
+  end
+
+  def update
+    Provider.transaction do
+      @nm = Provider.find_key(params[:id]).lock!
+      if request.patch?
+        patch(@nm,%w{name type auth_details})
+      else
+        @nm.update_attributes!(params.permit(:name, :type, :auth_details))
+      end
+    end
+    render api_show @nm
+  end
+
+  def create
+    params.require(:name)
+    params.require(:type)
+    params.require(:auth_details)
+    @provider = Provider.create!(name: params[:name],
+                                 type: params[:type],
+                                 auth_details: params[:auth_details])
+    render api_show @provider
+  end
+
+  def destroy
+    render api_delete Provider
+  end
+  
+end

--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -116,6 +116,13 @@ class Barclamp < ActiveRecord::Base
                                :client_role_name => jig_client_role)
       end if bc["jigs"]
 
+      bc['providers'].each do |provider|
+        Rails.logger.info("Importing provider #{provider['name']} for #{barclamp.name}")
+        p_obj = provider['class'].constantize.find_or_create_by!(name: provider['name'],
+                                                                 description: provider['description'])
+        p_obj.update_attributes!(auth_details: provider['auth_details']) if provider['auth_details']
+      end if bc['providers']
+
       # iterate over the roles in the yml file and load them all.
       # Jigs are now late-bound, so we just load everything.
       bc['roles'].each do |role|

--- a/rails/app/models/deployment.rb
+++ b/rails/app/models/deployment.rb
@@ -151,6 +151,7 @@ class Deployment < ActiveRecord::Base
                  admin: false,
                  system: true,
                  alive: true,
+                 variant: "phantom",
                  deployment_id: self.id,
                  bootenv: "local")
   end

--- a/rails/app/models/metal_provider.rb
+++ b/rails/app/models/metal_provider.rb
@@ -1,0 +1,33 @@
+# Copyright 2015 RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class MetalProvider < Provider
+
+  audited
+  has_many :nodes
+
+  def create_node(obj)
+    true
+  end
+
+  def reboot_node(obj)
+    obj.power.reboot
+  end
+
+  def delete_node(obj)
+    true
+  end
+
+end

--- a/rails/app/models/metal_provider.rb
+++ b/rails/app/models/metal_provider.rb
@@ -18,16 +18,8 @@ class MetalProvider < Provider
   audited
   has_many :nodes
 
-  def create_node(obj)
-    true
-  end
-
   def reboot_node(obj)
     obj.power.reboot
-  end
-
-  def delete_node(obj)
-    true
   end
 
 end

--- a/rails/app/models/provider.rb
+++ b/rails/app/models/provider.rb
@@ -1,0 +1,33 @@
+# Copyright 2015 RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class Provider < ActiveRecord::Base
+
+  audited
+  has_many :nodes
+
+  def create_node(obj)
+    true
+  end
+
+  def reboot_node(obj)
+    true
+  end
+
+  def delete_node(obj)
+    true
+  end
+
+end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -168,6 +168,13 @@ Rebar::Application.routes.draw do
               post 'match'
             end
           end
+          resources :providers do
+            collection do
+              get 'sample'
+              post 'match'
+            end
+            resources :nodes
+          end
           resources :deployment_roles do
             collection do
               get 'sample'

--- a/rails/db/migrate/20140430000001_drill_consolidated.rb
+++ b/rails/db/migrate/20140430000001_drill_consolidated.rb
@@ -172,6 +172,14 @@ class DrillConsolidated < ActiveRecord::Migration
       t.timestamps
     end
     add_index(:role_require_attribs, [:role_id, :attrib_name], :unique => true)
+
+    create_table :providers do |t|
+      t.text        :name,           null: false, unique: true
+      t.text        :type
+      t.text        :description,    null: false, default: "An undescribed provider"
+      t.json        :auth_details,   null: false, default: { expr: "'{}'::json" }
+      t.timestamps
+    end
     
     create_table :nodes do |t|
       t.text        :name,           limit: 255,     null: false
@@ -180,6 +188,7 @@ class DrillConsolidated < ActiveRecord::Migration
       t.boolean     :admin,          default: false
       t.integer     :target_role_id, null: true, foreign_key: { references: :roles }
       t.belongs_to  :deployment,     null: false
+      t.belongs_to  :provider,       null: false
       t.text        :variant,        null: false,   default: "metal"
       t.text        :arch,           null: false,   default: "x86_64"
       t.text        :os_family,      null: false,   default: "linux"

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -15,12 +15,6 @@
 # This file should contain all the record creation needed to seed the database with its default values.
 # The data can then be loaded with the rake db:seed (or created alongside the db with db:setup).
 ActiveRecord::Base.transaction do
-  # We always need a system deployment
-  Deployment.find_or_create_by!(name:        "system",
-                                description: I18n.t('automatic', :default=>"Created Automatically by System"),
-                                system:      true,
-                                state:       Deployment::COMMITTED)
-
 
   u = User.find_or_create_by_username!(:username=>'rebar', :password=>'rebar1', :is_admin=>true)
   u.digest_password('rebar1')

--- a/rebar-docker-install.sh
+++ b/rebar-docker-install.sh
@@ -30,6 +30,10 @@ while read bc; do
   /opt/digitalrebar/core/bin/barclamp_import "$bc"
 done < <(find /opt/digitalrebar -name rebar.yml |grep -v '/core/')
 
+# Create the system deployment
+# We always need a system deployment
+if ! rebar deployments create '{"name": "system", "description": "Created Automatically by System","system": true}'; then cat /var/log/rebar/production.log; exit 1; fi
+
 # We absolutely have to have an unmanaged-internal network, and there can
 # really only be one of them, so leave this hardcoded for now.
 unmanaged_net='


### PR DESCRIPTION
This adds the framework to let the Rebar node API drive an external
service.  This is inteded to let Rebar create, detroy, and manage nodes
in external clouds.