### PR TITLE
allows integers to be properly updated on all attribs with schema type 'int'

### DIFF
--- a/rails/app/controllers/attribs_controller.rb
+++ b/rails/app/controllers/attribs_controller.rb
@@ -123,7 +123,7 @@ class AttribsController < ApplicationController
       else
         params[:value] = params[:attrib][:value] if params[:attrib]
         params.require(:value)
-
+        params[:value] = params[:value].to_i if attrib.schema['type'] == 'int'
         target.attribs.find(attrib.id).set(target,params[:value], bucket)
         flash[:notice] = I18n.t('commit_required', :role => target.name)
         ret = attrib.as_json

--- a/rails/app/views/attribs/_default.html.haml
+++ b/rails/app/views/attribs/_default.html.haml
@@ -3,7 +3,12 @@
   %tr.node{ :class => cycle(:odd, :even) }
     %td= link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
     - if editable and attrib.writable
-      %td= text_field_tag :value, value, :size => 40
+      %td
+        - case attrib.schema['type'] #handle schema types so integers are actually valid
+        - when 'int'
+          =number_field_tag :value, value, :size => 40
+        - else
+          =text_field_tag :value, value, :size => 40
       %td{:align=>"right"}
         %input.button{:type => "submit", :name => "save", :value => t('save')}
     -else


### PR DESCRIPTION
if any attrib calls for an integer type, the attrib controller will now convert the string into an integer and allow it to be saved

fixes dhcp_leasetime attrib