### PR TITLE
Add node provider support.

### DIFF
--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -260,6 +260,23 @@ attribs:
     schema:
       type: str
       required: false
+  - name: provider-create-hint
+    description: 'Extra parameters to be passed to the provider at node create time'
+    map: 'provider/create_hints'
+    default: {}
+    schema:
+      type: map
+      mapping:
+        =:
+          type: any
+  - name: provider-node-id
+    description: 'The node ID as understood by the remote provider'
+    map: 'provider/node_id'
+  - name: node-control-address
+    description: 'The network address that should be used to control the node.  Will be used if no other address is reachable.'
+    map: 'provider/control_address'
+    schema:
+      type: str
 
 providers:
   - name: phantom

--- a/rails/app/models/fog_provider.rb
+++ b/rails/app/models/fog_provider.rb
@@ -1,0 +1,64 @@
+# Copyright 2015 RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+require 'diplomat'
+require 'jsonrpc-client'
+
+
+class FogProvider < Provider
+
+  audited
+  has_many :nodes
+
+  after_commit :register_endpoint, on: :create
+
+  def create_node(obj)
+    obj.with_lock do
+      if Attrib.get('provider-node-id',obj) != nil
+        Rails.logger.fatal("Trying to recreate #{obj.name} in provider #{self.class.name}")
+        Rails.logger.fatal(caller.join("\n"))
+        raise "Trying to recreate #{obj.name} in provider #{self.class.name}"
+      end
+      ep = endpoint
+      params = Attrib.get('provider-create-hint',obj) || {}
+      server = ep.invoke('servers.create',[self.auth_details,obj.id,params])
+      Rails.logger.info("Created server #{server.inspect}")
+      Attrib.set('provider-node-id',obj, server["id"], :hint)
+    end
+  end
+
+  def reboot_node(obj)
+    ep = endpoint
+    ep.invoke('servers.reboot',[self.auth_details,Attrib.get('provider-node-id',obj)])
+  end
+
+  def delete_node(obj)
+    ep = endpoint
+    ep.invoke('servers.delete',[self.auth_details,Attrib.get('provider-node-id',obj)])
+  end
+
+  private
+  def endpoint
+    service = Diplomat::Service.get('fogwrap')
+    JSONRPC::Client.new("http://#{service.Address}:#{service.ServicePort}")
+  end
+
+  def register_endpoint
+    ep = endpoint
+    ep.invoke('servers.register',[self.auth_details,
+                                  'rebar',
+                                  Attrib.get('rebar-access_keys',Deployment.system)])
+  end
+
+end

--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -165,11 +165,13 @@ class Node < ActiveRecord::Base
         end
       end
     end
+    control_address = Attrib.get('node-control-address',self)
+    res << IP.coerce(control_address) if control_address
     res.flatten
   end
 
   def address(filter = :all, networks = ["admin","unmanaged"])
-    res = addresses(filter,networks).detect{|a|a.reachable?}
+    res = addresses(filter,networks).detect{|a|a.reachable?} || Attrib.get('node-control-address',self)
     Rails.logger.warn("Node #{name} did not have any reachable addresses in networks #{networks.inspect}") unless res
     res
   end

--- a/rails/app/models/provider.rb
+++ b/rails/app/models/provider.rb
@@ -18,6 +18,10 @@ class Provider < ActiveRecord::Base
   audited
   has_many :nodes
 
+  def as_json(args = nil)
+    super(args).merge("type" => self.type.to_s)
+  end
+
   def create_node(obj)
     true
   end

--- a/rails/db/migrate/20140430000001_drill_consolidated.rb
+++ b/rails/db/migrate/20140430000001_drill_consolidated.rb
@@ -174,7 +174,7 @@ class DrillConsolidated < ActiveRecord::Migration
     add_index(:role_require_attribs, [:role_id, :attrib_name], :unique => true)
 
     create_table :providers do |t|
-      t.text        :name,           null: false, unique: true
+      t.text        :name,           null: false, index: :unique
       t.text        :type
       t.text        :description,    null: false, default: "An undescribed provider"
       t.json        :auth_details,   null: false, default: { expr: "'{}'::json" }


### PR DESCRIPTION
This adds the framework to let the Rebar node API drive an external
service.  This is inteded to let Rebar create, detroy, and manage nodes
in external clouds.

It includes initial support for driving Fog to support other clouds,
though this has only recieved light testing with AWS.