### PR TITLE
fix bad default for record, needed to be json

### DIFF
--- a/rails/db/migrate/20140430000001_drill_consolidated.rb
+++ b/rails/db/migrate/20140430000001_drill_consolidated.rb
@@ -21,8 +21,8 @@ class DrillConsolidated < ActiveRecord::Migration
 
     # 20140122123641
     create_table :settings do |t|
-      t.text       :var,    null: false
-      t.text       :value,  null: false, default: ''
+      t.string     :var,    null: false
+      t.text       :value,  null: false, default: '--- {}'
       t.references :target, null: false, polymorphic: true
       t.timestamps
     end


### PR DESCRIPTION
This issue was created when I was overly enthusiastic about the database migration normalization.

solution help > https://stackoverflow.com/questions/16638979/attribute-was-supposed-to-be-a-hash-but-was-a-string/25551313#25551313

connect to #870 