### PR TITLE
Render JSON better for attribs and HIDE big json blocks unde toggle

### DIFF
--- a/barclamps/chef.yml
+++ b/barclamps/chef.yml
@@ -69,6 +69,7 @@ roles:
       - name: chef-client_key
         description: 'The private key that this node should use to authenticate with the chef server'
         map: 'chefjig/client/key'
+        ui_renderer: 'barclamp_chef/attribs/client_key'
     wants-attribs:
       - chef-servers
   - name: chef-solo

--- a/rails/app/views/attribs/_default.html.haml
+++ b/rails/app/views/attribs/_default.html.haml
@@ -19,7 +19,7 @@
     -else
       - if value.is_a? Hash or value.is_a? Array
         %td
-          %a.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
+          %span.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
             = truncate value.to_s, :length=>120
           %pre{:id=>"rawdata_#{attrib.id}", :style =>"display:none"}
             = JSON.pretty_generate(value)

--- a/rails/app/views/attribs/_default.html.haml
+++ b/rails/app/views/attribs/_default.html.haml
@@ -17,7 +17,13 @@
       %td{:align=>"right"}
         %input.button{:type => "submit", :name => "save", :value => t('save')}
     -else
-      - if value
+      - if value.is_a? Hash or value.is_a? Array
+        %td
+          %a.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
+            = truncate value.to_s, :length=>120
+          %pre{:id=>"rawdata_#{attrib.id}", :style =>"display:none"}
+            = JSON.pretty_generate(value)
+      - elsif value
         %td= value
       - else
         %td= t('not_set')

--- a/rails/app/views/barclamp_chef/attribs/_client_key.html.haml
+++ b/rails/app/views/barclamp_chef/attribs/_client_key.html.haml
@@ -1,0 +1,15 @@
+- value = Attrib.get(attrib.name, obj)
+%tr.node{ :class => cycle(:odd, :even) }
+  %td
+    = link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
+    - if flag == :error
+      = image_tag('icons/error.png', :title=>error)
+    - if flag == :raw
+      = image_tag('icons/raw.png', :title=>"raw mode")
+    %td
+      %a.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
+        = truncate value.to_s, :length=>60
+      %pre{:id=>"rawdata_#{attrib.id}", :style =>"display:none"}
+        = value
+    - if current_user and current_user.settings(:ui).debug
+      %td= attrib.ui_renderer rescue Attrib::UI_RENDERER

--- a/rails/app/views/barclamp_chef/attribs/_client_key.html.haml
+++ b/rails/app/views/barclamp_chef/attribs/_client_key.html.haml
@@ -7,7 +7,7 @@
     - if flag == :raw
       = image_tag('icons/raw.png', :title=>"raw mode")
     %td
-      %a.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
+      %span.toggle.with_label{:href => "#", :id => "#toggle_#{attrib.id}", :rel => "rawdata_#{attrib.id}" }
         = truncate value.to_s, :length=>60
       %pre{:id=>"rawdata_#{attrib.id}", :style =>"display:none"}
         = value

--- a/rails/app/views/barclamp_provisioner/attribs/_supported_oses.html.haml
+++ b/rails/app/views/barclamp_provisioner/attribs/_supported_oses.html.haml
@@ -1,0 +1,7 @@
+- value_raw = Attrib.get(attrib.name, obj)
+- value = value_raw.map{ |k, v| k } rescue [ t('not_set') ]
+%tr
+  %td= link_to attrib.name_i18n, attrib_path(attrib.id), :title=>attrib.description
+  %td= value.sort.join ", "
+  - if current_user and current_user.settings(:ui).debug
+    %td= attrib.ui_renderer rescue Attrib::UI_RENDERER


### PR DESCRIPTION
Also, do not show the chef-client key by default

Makes the screen much more compact and does not show noise