### PR TITLE
add node control address to UI

### DIFF
--- a/rails/app/views/deployments/show.html.haml
+++ b/rails/app/views/deployments/show.html.haml
@@ -122,7 +122,9 @@
       alert(JSON.parse(xhr.responseText)["message"]);
       })
     .bind("ajax:success", function(data, status, xhr){
-      location.reload();
+      setTimeout(function(){
+        location.reload();
+      }, 1000);
       });
 
   // set hover showing

--- a/rails/app/views/node_roles/anneal.html.haml
+++ b/rails/app/views/node_roles/anneal.html.haml
@@ -34,5 +34,7 @@
       console.log("/api/v2/node_roles/"+id+"/retry");
       $.ajax({url: "/api/v2/node_roles/"+id+"/retry", type: "PUT"})
     };
-    location.reload();
+    setTimeout(function(){
+      location.reload();
+    }, 1000);
   }

--- a/rails/app/views/nodes/_index.html.haml
+++ b/rails/app/views/nodes/_index.html.haml
@@ -3,6 +3,7 @@
     %tr
       %th
       %th= t '.name'
+      %th= t '.address'
       %th= t '.status'
       %th= t '.admin'
       %th= t '.description'
@@ -19,6 +20,7 @@
         %td.status{ :width=>'10px'}
           .led{:class => led, :title=>t(".#{led}"), :raw => s}
         %td= link_to n.name, node_path(n.id)
+        %td= n.get_attrib('node-control-address')
         %td.strStatus
           = t (n.alive ? ".alive" : ".dead")
           = t (n.available ? ".available" : ".reserved")

--- a/rails/app/views/nodes/_show.html.haml
+++ b/rails/app/views/nodes/_show.html.haml
@@ -1,43 +1,42 @@
 - state = @node.state
 
-.column_50.first
-  %dl
-    = dl_item(t('.name'), @node.name)
-    = dl_item(t('.description'), @node.description || (t 'not_set'))
-    %dt= t '.deployment'
-    %dd
-      = form_for :node_deployment, :remote => true, :url => node_path(:id=>@node.id), :html => { :method=>:put, :'data-type' => 'json', :class => "formtastic", :onsubmit=>"location.reload();" } do |f|
-        - deployments = Deployment.all
-        = f.collection_select :deployment_id, deployments, :id, :name, :selected=>@node.deployment.id
-        %input.button{:type => "submit", :name => "update", :value => t('update'), }
-    = dl_item t('.bootenv'), t(".#{@node.bootenv}", :default=>@node.bootenv)
-    %dt= t('.status')
-    %dd
-      = t (@node.alive ? ".alive" : ".dead")
-      = t (@node.available ? ".available" : ".reserved")
-      = NodeRole.state_name(state)
-      = link_to t((@node.available ? '.reserve' : '.release')), node_path(@node.id, :api_version=>'v2', :available=>!@node.available), 
-                    :method=>:put, :class=>'button', :remote=>true, :onclick=>"location.reload();"
-
-.column_50.last
-  %dl
-    = dl_item(t('.vendor'), "#{@node.attrib_system_manufacturer} #{@node.attrib_system_product}")
-    = dl_item(t('.serial'), @node.attrib_system_serial_number)
-    = dl_item(t('.asset_tag'), @node.attrib_asset_tag)
-    = dl_item(t('.hardware'), @node.attrib_hardware)
-    %dt= t('.cpu')
-    %dd
-      - raw =@node.attrib_cpu || t('unknown')
-      - if raw.start_with? "Intel(R)"
-        = image_tag("http://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Intel-logo.svg/293px-Intel-logo.svg.png", height: 16, title:"Intel")
-        - raw = raw.gsub("Intel(R) ",'')
-      - raw = raw.gsub("CPU ", '')
-      = raw
-    = dl_item(t('.memory'), format_memory(@node.attrib_memory))
-    = dl_item(t('.number_of_drives'), "#{@node.attrib_number_of_drives || 0}, #{t('.raid')}: #{t('.'+(@node.attrib_raid_set || 'not_set'))}")
-    = dl_item(t('.operating_system'), "#{@node.attrib_os_description || ((@node.attrib_os || "Unknown") + " " + (@node.attrib_os_version || ""))}")
-    - if Rails.env.development? and Jig.active('test')
-      %dt= t '.bdd_marker'
-      %dd= @node.attrib_bdd_marker || t('ignore')
+%dl
+  %dt= t('.name')
+  %dd
+    = @node.name
     = link_to "Destroy", node_path(@node.id, :api_version=>2), :class => 'button', :method => :delete, data: { confirm: "Are you certain you want to destroy #{@node.name}?" }
+  = dl_item(t('.description'), @node.description || (t 'not_set'))
+  %dt= t '.deployment'
+  %dd
+    = form_for :node_deployment, :remote => true, :url => node_path(:id=>@node.id), :html => { :method=>:put, :'data-type' => 'json', :class => "formtastic", :onsubmit=>"location.reload();" } do |f|
+      - deployments = Deployment.all
+      = f.collection_select :deployment_id, deployments, :id, :name, :selected=>@node.deployment.id
+      %input.button{:type => "submit", :name => "update", :value => t('update'), }
+  = dl_item t('.bootenv'), t(".#{@node.bootenv}", :default=>@node.bootenv)
+  = dl_item t('.address'), @node.get_attrib('node-control-address')
+  %dt= t('.status')
+  %dd
+    = t (@node.alive ? ".alive" : ".dead")
+    = t (@node.available ? ".available" : ".reserved")
+    = NodeRole.state_name(state)
+    = link_to t((@node.available ? '.reserve' : '.release')), node_path(@node.id, :api_version=>'v2', :available=>!@node.available), 
+                  :method=>:put, :class=>'button', :remote=>true, :onclick=>"location.reload();"
+  = dl_item(t('.vendor'), "#{@node.attrib_system_manufacturer} #{@node.attrib_system_product}")
+  = dl_item(t('.serial'), @node.attrib_system_serial_number)
+  = dl_item(t('.asset_tag'), @node.attrib_asset_tag)
+  = dl_item(t('.hardware'), @node.attrib_hardware)
+  %dt= t('.cpu')
+  %dd
+    - raw =@node.attrib_cpu || t('unknown')
+    - if raw.start_with? "Intel(R)"
+      = image_tag("http://upload.wikimedia.org/wikipedia/commons/thumb/c/c9/Intel-logo.svg/293px-Intel-logo.svg.png", height: 16, title:"Intel")
+      - raw = raw.gsub("Intel(R) ",'')
+    - raw = raw.gsub("CPU ", '')
+    = raw
+  = dl_item(t('.memory'), format_memory(@node.attrib_memory))
+  = dl_item(t('.number_of_drives'), "#{@node.attrib_number_of_drives || 0}, #{t('.raid')}: #{t('.'+(@node.attrib_raid_set || 'not_set'))}")
+  = dl_item(t('.operating_system'), "#{@node.attrib_os_description || ((@node.attrib_os || "Unknown") + " " + (@node.attrib_os_version || ""))}")
+  - if Rails.env.development? and Jig.active('test')
+    %dt= t '.bdd_marker'
+    %dd= @node.attrib_bdd_marker || t('ignore')
 .clear

--- a/rails/app/views/nodes/show.html.haml
+++ b/rails/app/views/nodes/show.html.haml
@@ -39,22 +39,26 @@
   - else
     = dl_item(t('.switch_name'), t('.switch_no_link'))
 
-%table.data.box
-  %thead
-    %tr
-      %th= t ".network"
-      %th= t ".range"
-      %th= t ".address"
-      %th= t ".conduit"
-      %th= t ".vlan"
-  %tbody
-    - @node.network_allocations.order("id ASC").each do |a|
-      %tr{:class => cycle("even", "odd")}
-        %td= link_to a.network.name, network_path(a.network.id)
-        %td= a.network_range.name
-        %td= a.address.to_s
-        %td= a.network_range.conduit
-        %td= a.network_range.use_vlan? ? a.network_range.vlan : t("none")
+- if @node.network_allocations.count > 0
+  %table.data.box
+    %thead
+      %tr
+        %th= t ".network"
+        %th= t ".range"
+        %th= t ".address"
+        %th= t ".conduit"
+        %th= t ".vlan"
+    %tbody
+      - @node.network_allocations.order("id ASC").each do |a|
+        %tr{:class => cycle("even", "odd")}
+          %td= link_to a.network.name, network_path(a.network.id)
+          %td= a.network_range.name
+          %td= a.address.to_s
+          %td= a.network_range.conduit
+          %td= a.network_range.use_vlan? ? a.network_range.vlan : t("none")
+- else
+  %dl
+    = dl_item t('.address'), @node.get_attrib('node-control-address')
 
 %h3= t '.node_roles'
 - node_roles = NodeRole.committed_by_node(@node).order("cohort, id")

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -359,6 +359,7 @@ en:
     index:
       title: "Nodes"
       admin: "Admin?"
+      address: "Address"
       no_nodes: "No Nodes Registered.  Suggested action: configure Rebar."
       <<: *deployment_common
       <<: *node_role_states
@@ -367,6 +368,7 @@ en:
       alive: "Alive"
       available: "Available"
       addresses: "Networking"
+      address: "Control Address"
       all_node_roles: "All Node Roles"
       admin: "(Admin)"
       system: "(System)"


### PR DESCRIPTION
@galthaus found that systems w/o Rebar controlled networks need to have this exposed.

Added control address on master nodes list and top of node display page.
If no networks are configured, UI will show control address too.

Some minor cleanups also on node show page and delays on ajax buttons

connect to #916