### PR TITLE
Decrease variability in noderole binding.

### DIFF
--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -77,9 +77,9 @@ class NodeRolesController < ApplicationController
     role = Role.find_key(params[:role] || params[:role_id] || nr_roles)
     depl ||= node.deployment
     begin
-      @node_role = NodeRole.safe_create!(role_id: role.id,
-                                         node_id: node.id,
-                                         deployment_id: depl.id)
+        @node_role = NodeRole.safe_create!(role_id: role.id,
+                                           node_id: node.id,
+                                           deployment_id: depl.id)
     rescue StandardError => e
       Rails.logger.fatal("Exception on safe_create!: #{e.message}")
       Rails.logger.fatal(e.backtrace)

--- a/rails/app/models/network.rb
+++ b/rails/app/models/network.rb
@@ -177,14 +177,7 @@ class Network < ActiveRecord::Base
   end
 
   def make_node_role(node)
-    nr = nil
-    NodeRole.transaction do
-      # do we have an existing NR?
-      nr = NodeRole.where(:node_id => node.id, :role_id => role.id).first
-      # if not, we have to create one
-      nr ||= role.add_to_node(node)
-    end
-    nr
+    role.add_to_node(node)
   end
 
   private

--- a/rails/app/models/role.rb
+++ b/rails/app/models/role.rb
@@ -242,11 +242,6 @@ class Role < ActiveRecord::Base
 
   # Bind a role to a node in a deployment.
   def add_to_node_in_deployment(node,dep)
-    Role.transaction do
-      # If we are already bound to this node in a deployment, do nothing.
-      res = NodeRole.find_by(node_id: node.id, role_id: self.id)
-      return res if res
-    end
     Rails.logger.info("Role: Trying to add #{name} to #{node.name}")
     NodeRole.safe_create!(node_id:       node.id,
                           role_id:       id,


### PR DESCRIPTION
When a noderole binding has to create its parents, that process should
now scale more linerally and not be subject to exponential slowdown when
it has to deal with cluster roles.