### PR TITLE
Ansible playbook enhancements

### DIFF
--- a/etc/init.d/rebar
+++ b/etc/init.d/rebar
@@ -74,21 +74,21 @@ start_workers() {
 }
 
 stop_workers() {
-    pkill -f que:work
+    pkill -f bin/que
     COUNT=0
-    while pgrep -l -f que:work 2>&1 >/dev/null ;
+    while pgrep -l -f bin/que 2>&1 >/dev/null ;
     do
         sleep 1
         COUNT=`expr $COUNT + 1`
         if [[ $COUNT -gt 30 ]] ;
         then
-            pkill -9 -f que:work
+            pkill -9 -f bin/que
         fi
     done
 }
 
 status_workers() {
-    pgrep -l -f que:work
+    pgrep -l -f bin/que
 }
 
 start(){

--- a/rails/app/models/barclamp_dhcp/mgmt_service.rb
+++ b/rails/app/models/barclamp_dhcp/mgmt_service.rb
@@ -100,7 +100,7 @@ class BarclampDhcp::MgmtService < Service
       end
       break if next_server
     end
-    Rails.logger.fatal("GREG: Missing next_server") unless next_server
+    Rails.logger.fatal('Missing next_server') unless next_server
 
     options = {}
     # Option 6 - name servers
@@ -118,7 +118,7 @@ class BarclampDhcp::MgmtService < Service
       end
       break if dns_server
     end
-    Rails.logger.fatal("GREG: Missing dns_server") unless dns_server
+    Rails.logger.fatal('Missing dns_server') unless dns_server
     options[6] = dns_server
     options[15] = dns_domain
 
@@ -211,9 +211,6 @@ class BarclampDhcp::MgmtService < Service
     store = OpenSSL::X509::Store.new
     store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
 
-Rails.logger.fatal("GREG: put url  = #{url}")
-Rails.logger.fatal("GREG: put data = #{data.to_json}")
-
     RestClient::Resource.new(
         url,
         :ssl_cert_store =>  store,
@@ -225,9 +222,6 @@ Rails.logger.fatal("GREG: put data = #{data.to_json}")
     store = OpenSSL::X509::Store.new
     store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
 
-Rails.logger.fatal("GREG: post url  = #{url}")
-Rails.logger.fatal("GREG: post data = #{data.to_json}")
-
     RestClient::Resource.new(
         url,
         :ssl_cert_store =>  store,
@@ -238,8 +232,6 @@ Rails.logger.fatal("GREG: post data = #{data.to_json}")
   def self.send_request_delete(url, ca_string)
     store = OpenSSL::X509::Store.new
     store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
-
-Rails.logger.fatal("GREG: delete url  = #{url}")
 
     RestClient::Resource.new(
         url,

--- a/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
+++ b/rails/app/models/barclamp_rebar/ansible_playbook_jig.rb
@@ -65,7 +65,7 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
       unless File.exists?("#{role_cache_dir}")
         # If we are told galaxy, then load it into ansible.
         if role_yaml['playbook_src_path'] =~ /^galaxy:/
-          out, err, status = exec_cmd("ansible-galaxy install #{role_yaml['playbook_src_path'].split(":")[1]}")
+          out, err, status = exec_cmd("sudo ansible-galaxy install #{role_yaml['playbook_src_path'].split(":")[1]}")
           die "Failed to get @ #{role_file}: #{out} #{err}" unless status.success?
 
           out, err, status = exec_cmd("mkdir -p #{role_cache_dir}")
@@ -137,7 +137,7 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
       File.open("#{role_cache_dir}/#{role_yaml['playbook_path']}/cluster.yml", "w") do |f|
         f.write("- hosts: #{role_map[nr.role.name]}\n")
         f.write("  roles:\n");
-        f.write("    - role_map[nr.role.name]\n")
+        f.write("    - #{role_map[nr.role.name]}\n")
       end
     else
       role_file = role_yaml['playbook_file']
@@ -145,8 +145,8 @@ class BarclampRebar::AnsiblePlaybookJig < Jig
 
     rns = role_map[nr.role.name]
     rns = [ nr.role.name ] unless rns
-    out,err,ok = exec_cmd("cd #{role_cache_dir}/#{role_yaml['playbook_path']} ; ansible-playbook -l #{nr.node.address.addr} -i #{rundir}/inventory.ini --extra-vars \"@#{rundir}/rebar.json\" #{role_yaml['playbook_file']} --tags=#{rns.join(',')}")
-    die("Running: cd #{role_cache_dir}/#{role_yaml['playbook_path']} ; ansible-playbook -l #{nr.node.address.addr} -i #{rundir}/inventory.ini --extra-vars \"@#{rundir}/rebar.json\" #{role_yaml['playbook_file']} --tags=#{rns.join(',')}\nScript jig run for #{nr.role.name} on #{nr.node.name} failed! (status = #{$?.exitstatus})\nOut: #{out}\nErr: #{err}") unless ok.success?
+    out,err,ok = exec_cmd("cd #{role_cache_dir}/#{role_yaml['playbook_path']} ; ansible-playbook -l #{nr.node.address.addr} -i #{rundir}/inventory.ini --extra-vars \"@#{rundir}/rebar.json\" #{role_file} --tags=#{rns.join(',')}")
+    die("Running: cd #{role_cache_dir}/#{role_yaml['playbook_path']} ; ansible-playbook -l #{nr.node.address.addr} -i #{rundir}/inventory.ini --extra-vars \"@#{rundir}/rebar.json\" #{role_file} --tags=#{rns.join(',')}\nScript jig run for #{nr.role.name} on #{nr.node.name} failed! (status = #{$?.exitstatus})\nOut: #{out}\nErr: #{err}") unless ok.success?
     nr.update!(runlog: out)
 
     # Now, we need to suck any written attributes back out.


### PR DESCRIPTION
Start support for Ansible galaxy - kinda like chef berkshelf pulling from a common repo.
Add the ability to inject network information from a function like things in ansible-playbooks.  It is kinda cheesy, but will work for now until we get a better pattern.

Update the nic detection code to record info which was generally busted.  This runs before we might have nics or configured admin networks. 

Fix restart rebar (wasn't killing the que workers).

Remove some debug statements