### PR TITLE
Update provisioner to use HTTP with latest syslinux.

### DIFF
--- a/chef/cookbooks/provisioner/providers/bootfile.rb
+++ b/chef/cookbooks/provisioner/providers/bootfile.rb
@@ -17,6 +17,7 @@
 action :add do
   nodeaddr = sprintf("%08X",new_resource.address.address)
   tftproot = node["rebar"]["provisioner"]["server"]["root"]
+  provisioner_web=node['rebar']['provisioner']['server']['webservers'].first["url"]
   discover_dir="#{tftproot}/discovery"
   uefi_dir=discover_dir
   pxecfg_dir="#{discover_dir}/pxelinux.cfg"
@@ -30,8 +31,8 @@ action :add do
     source "default.#{extra}erb"
     variables(:append_line => new_resource.kernel_params,
               :install_name => new_resource.bootenv,
-              :initrd => new_resource.initrd,
-              :kernel => new_resource.kernel)
+              :initrd => "#{provisioner_web}/#{new_resource.initrd}",
+              :kernel => "#{provisioner_web}/#{new_resource.kernel}")
   end
   template uefifile do
     mode 0644

--- a/chef/cookbooks/provisioner/resources/bootfile.rb
+++ b/chef/cookbooks/provisioner/resources/bootfile.rb
@@ -16,8 +16,8 @@
 actions :add, :remove
 
 attribute :name, :kind_of => String, :name_attribute => true
-attribute :initrd, :kind_of => String, :default => "initrd0.img"
-attribute :kernel, :kind_of => String, :default => "vmlinuz0"
+attribute :initrd, :kind_of => String, :default => "discovery/initrd0.img"
+attribute :kernel, :kind_of => String, :default => "discovery/vmlinuz0"
 attribute :address, :kind_of => IP, :required => true
 attribute :bootenv, :kind_of => String, :required => "true"
 attribute :kernel_params, :kind_of => String, :default => ""

--- a/chef/cookbooks/provisioner/templates/default/default.erb
+++ b/chef/cookbooks/provisioner/templates/default/default.erb
@@ -4,6 +4,6 @@ TIMEOUT 10
 LABEL <%= @install_name %>
   KERNEL <%= @kernel %>
 <% iird="" -%>
-<% iird="initrd=../#{@initrd}" if @initrd and @initrd != "" -%>
+<% iird="initrd=#{@initrd}" if @initrd and @initrd != "" -%>
   append <%= iird %> <%= @append_line %>
   IPAPPEND 2

--- a/rails/app/models/barclamp_dhcp/mgmt_service.rb
+++ b/rails/app/models/barclamp_dhcp/mgmt_service.rb
@@ -125,7 +125,7 @@ class BarclampDhcp::MgmtService < Service
     # Option 3 - gateway
     options[3] = network.network_router.address.addr if network and network.network_router
     # GREG: One day this needs to be selectable by arch
-    options[67] = "discovery/pxelinux.0"
+    options[67] = "discovery/lpxelinux.0"
 
     self.class.create_network(network.name, subnet, next_server, start_ip, end_ip, options)
   end
@@ -306,7 +306,7 @@ class BarclampDhcp::MgmtService < Service
       options = {}
     else
       options = {}
-      options[67] = "discovery/pxelinux.0"
+      options[67] = "discovery/lpxelinux.0"
       # GREG: One day this needs to be selectable by arch
     end
     options.each do |k,v|


### PR DESCRIPTION
Syslinux 6.03 adds support for pulling things via http as well as tftp.
It consumes way less CPU that tftp, so use it.