### PR TITLE
Get rid of white space in migrate file

### DIFF
--- a/rails/app/models/fog_provider.rb
+++ b/rails/app/models/fog_provider.rb
@@ -18,9 +18,6 @@ require 'jsonrpc-client'
 
 class FogProvider < Provider
 
-  audited
-  has_many :nodes
-
   after_commit :register_endpoint, on: :create
 
   def create_node(obj)

--- a/rails/app/models/metal_provider.rb
+++ b/rails/app/models/metal_provider.rb
@@ -15,9 +15,6 @@
 
 class MetalProvider < Provider
 
-  audited
-  has_many :nodes
-
   def reboot_node(obj)
     obj.power.reboot
   end

--- a/rails/app/models/packet_provider.rb
+++ b/rails/app/models/packet_provider.rb
@@ -18,9 +18,6 @@ require 'jsonrpc-client'
 
 class PacketProvider < Provider
 
-  audited
-  has_many :nodes
-
   after_commit :register_endpoint, on: :create
 
   def create_node(obj)

--- a/rails/db/migrate/20140430000001_drill_consolidated.rb
+++ b/rails/db/migrate/20140430000001_drill_consolidated.rb
@@ -155,7 +155,6 @@ class DrillConsolidated < ActiveRecord::Migration
       t.references  :parent
       t.timestamps
     end
-    
 
     create_table :role_requires do |t|
       t.belongs_to  :role,            null: false
@@ -180,7 +179,7 @@ class DrillConsolidated < ActiveRecord::Migration
       t.json        :auth_details,   null: false, default: { expr: "'{}'::json" }
       t.timestamps
     end
-    
+
     create_table :nodes do |t|
       t.text        :name,           limit: 255,     null: false
       t.text        :description,    null: false, default: ''


### PR DESCRIPTION
Get rid of extra audited and nodes refs in sub-classes.
Only use the parent ones.