### PR TITLE
use provider POST to create nodes with basic hints

### DIFF
--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -49,7 +49,7 @@ class NodesController < ApplicationController
               Node.all
             end
     respond_to do |format|
-      format.html { @list.to_a.delete_if { |n| n.system }}
+      format.html { @list.to_a.delete_if { |n| n.system } }
       format.json { render api_index Node, @list.to_a }
     end
   end

--- a/rails/app/models/provider.rb
+++ b/rails/app/models/provider.rb
@@ -38,8 +38,4 @@ class Provider < ActiveRecord::Base
     false
   end
 
-  def friendly_name
-    "#{type.sub("Provider","")}: #{name}"
-  end
-
 end

--- a/rails/app/views/nodes/_index.html.haml
+++ b/rails/app/views/nodes/_index.html.haml
@@ -7,8 +7,8 @@
       %th= t '.status'
       %th= t '.admin'
       %th= t '.description'
-      %th= t '.provider'
-      %th= t '.deployment'
+      %th= link_to t('.provider'), providers_path
+      %th= link_to t('.deployment'), deployments_path
   %tbody.nodelist
     -nodes.each do |n|
       - s = n.state

--- a/rails/app/views/nodes/index.html.haml
+++ b/rails/app/views/nodes/index.html.haml
@@ -1,4 +1,20 @@
-%h1= t '.title'
+- providers = Provider.all.to_a.keep_if { |p| p.can_create_nodes }
+- available_os = Attrib.get("provisioner-available-oses", admin).map{ |k,v| k } rescue [ t('default') ]
+
+%table{:width=>'100%'}
+  %tr
+    %td
+      %h1= t '.title'
+    %td{:align=>'right'}
+      - if providers and providers.count > 0
+        = link_to t('.create_nodes'), providers_path
+        = text_field_tag :name, t('.name_base'), :size => 15
+        = select :add, :provider, options_for_select(providers.map{|p| p.name}, providers.first)
+        = select :add, :os, options_for_select(available_os, available_os.first)
+        = text_field_tag :number, 1, :size => 2
+        %button{:onclick=>"add_nodes()"}= t('add')
+      - else
+        = link_to ('.no_providers'), providers_path
 
 - if @list.length == 0
   %p= t '.no_nodes'
@@ -8,6 +24,38 @@
 .clear
 
 :javascript
+
+  function add_nodes() {
+    var base_name = $("#name").val();
+    var provider = $("#add_provider").val();
+    var os = $("#add_os").val();
+    var number = parseInt($("#number").val());
+    for (var i=0; i<number; i++) {
+      $.post("#{nodes_path}",
+        {
+          name: base_name+"_"+i+"."+provider+".neode.org",
+          description: "created by #{current_user.username}",
+          provider: provider,
+          hints: { 
+            'use-proxy': false,
+            'use-ntp': false,
+            'use-dns': false,
+            'use-logging': false,
+            'provider-create-hint': { 
+              os: os,
+              hostname: base_name+"_"+i
+              }
+            }
+          },
+        function(data, status){ 
+          if (status=="success") { location.reload(); } 
+      })
+      .fail(function(jqXHR, textStatus, errorThrown) {
+        alert("#{t('.create_failed')}: " + textStatus + " " + errorThrown);
+        //break;
+      });
+    };
+  }
 
   function update() {
 

--- a/rails/app/views/providers/show.html.haml
+++ b/rails/app/views/providers/show.html.haml
@@ -5,7 +5,7 @@
   %table.data.box
     %thead
       %tr
-        %th= t ".name"
+        %th= link_to t(".name"), providers_path
         %th= @item.name
     %tbody
       %tr

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -368,8 +368,10 @@ en:
       address: "Address"
       no_nodes: "No Nodes Registered.  Suggested action: configure Rebar."
       provider: "Provider"
-      create_nodes: "Create Nodes"
+      create_nodes: "Provider Nodes"
+      name_base: "digital_rebar_node"
       no_providers: "No Drivable Providers"
+      create_failed: "Create Failed"
       <<: *deployment_common
       <<: *node_role_states
     show:


### PR DESCRIPTION
From the Node List page, you can now use the Providers to CREATE Nodes.

AJAX use base name and providers to build basic post.

FQDN plug for now