### PR TITLE
Start working on rationalizing how Consul services interact with core.

### DIFF
--- a/rails/app/models/barclamp_chef/service.rb
+++ b/rails/app/models/barclamp_chef/service.rb
@@ -16,6 +16,7 @@
 class BarclampChef::Service < Service
 
   def do_transition(nr, data)
+    deployment_name = nr.deployment.name
     internal_do_transition(nr, data, "chef-service", "chef-servers") do |s|
       str_addr = s.ServiceAddress
       str_addr = s.Address if str_addr.nil? or str_addr.empty?
@@ -24,10 +25,9 @@ class BarclampChef::Service < Service
       Rails.logger.debug("ChefServer: #{addr.inspect}")
 
       # TODO: THIS NEEDS TO RUN ON ALL RUNNERS AND API SERVERS
-      server_name = s.ServiceTags.first
-      proto = ConsulAccess.getKey("digitalrebar/private/chef/#{server_name}/proto")
-      key = ConsulAccess.getKey("digitalrebar/private/chef/#{server_name}/pem")
-      account = ConsulAccess.getKey("digitalrebar/private/chef/#{server_name}/account")
+      proto = ConsulAccess.getKey("digitalrebar/private/chef/#{deployment_name}/proto")
+      key = ConsulAccess.getKey("digitalrebar/private/chef/#{deployment_name}/pem")
+      account = ConsulAccess.getKey("digitalrebar/private/chef/#{deployment_name}/account")
 
       url = "#{proto}://"
       if addr.v6?

--- a/rails/app/models/barclamp_dhcp/mgmt_service.rb
+++ b/rails/app/models/barclamp_dhcp/mgmt_service.rb
@@ -19,6 +19,7 @@ require 'uri'
 class BarclampDhcp::MgmtService < Service
 
   def do_transition(nr,data)
+    deployment_name = nr.deployment.name
     internal_do_transition(nr, data, 'dhcp-mgmt-service', 'dhcp-management-servers') do |s|
       str_addr = s.ServiceAddress
       str_addr = s.Address if str_addr.nil? or str_addr.empty?
@@ -26,10 +27,9 @@ class BarclampDhcp::MgmtService < Service
       addr = IP.coerce(str_addr)
       Rails.logger.debug("DhcpMgmtService: #{addr.inspect}")
 
-      server_name = s.ServiceTags.first
-      cert_pem = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{server_name}/cert_pem")
-      access_name = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{server_name}/access_name")
-      access_password = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{server_name}/access_password")
+      cert_pem = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{deployment_name}/cert_pem")
+      access_name = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{deployment_name}/access_name")
+      access_password = ConsulAccess.getKey("digitalrebar/private/dhcp-mgmt/#{deployment_name}/access_password")
 
       if addr.v6?
         saddr = "[#{addr.addr}]"
@@ -40,7 +40,7 @@ class BarclampDhcp::MgmtService < Service
 
       { 'address' => str_addr,
         'port' => "#{s.ServicePort}",
-        'name' => server_name,
+        'name' => deployment_name,
         'cert' => cert_pem,
         'access_name' => access_name,
         'access_password' => access_password,

--- a/rails/app/models/barclamp_dns/mgmt_service.rb
+++ b/rails/app/models/barclamp_dns/mgmt_service.rb
@@ -19,6 +19,7 @@ require 'uri'
 class BarclampDns::MgmtService < Service
 
   def do_transition(nr,data)
+    deployment_name = nr.deployment.name
     internal_do_transition(nr, data, 'dns-mgmt-service', 'dns-management-servers') do |s|
       str_addr = s.ServiceAddress
       str_addr = s.Address if str_addr.nil? or str_addr.empty?
@@ -26,10 +27,9 @@ class BarclampDns::MgmtService < Service
       addr = IP.coerce(str_addr)
       Rails.logger.debug("DnsMgmtServer: #{addr.inspect}")
 
-      server_name = s.ServiceTags.first
-      cert_pem = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{server_name}/cert_pem")
-      access_name = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{server_name}/access_name")
-      access_password = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{server_name}/access_password")
+      cert_pem = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{deployment_name}/cert_pem")
+      access_name = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{deployment_name}/access_name")
+      access_password = ConsulAccess.getKey("digitalrebar/private/dns-mgmt/#{deployment_name}/access_password")
 
       if addr.v6?
         saddr = "[#{addr.addr}]"
@@ -40,7 +40,7 @@ class BarclampDns::MgmtService < Service
 
       { 'address' => str_addr,
         'port' => "#{s.ServicePort}",
-        'name' => server_name,
+        'name' => deployment_name,
         'cert' => cert_pem,
         'access_name' => access_name,
         'access_password' => access_password,

--- a/rails/app/models/barclamp_dns/service.rb
+++ b/rails/app/models/barclamp_dns/service.rb
@@ -16,6 +16,7 @@
 class BarclampDns::Service < Service
 
   def do_transition(nr, data)
+    deployment_name = nr.deployment.name
     internal_do_transition(nr, data, "dns-service", "dns_servers") do |s|
       str_addr = s.ServiceAddress
       str_addr = s.Address if str_addr.nil? or str_addr.empty?
@@ -23,18 +24,17 @@ class BarclampDns::Service < Service
       addr = IP.coerce(str_addr)
       Rails.logger.debug("DnsServer: #{addr.inspect}")
 
-      server_name = s.ServiceTags.first
-      server_type = ConsulAccess.getKey("digitalrebar/private/dns/#{server_name}/type")
+      server_type = ConsulAccess.getKey("digitalrebar/private/dns/#{deployment_name}/type")
 
       res = { "address" => str_addr,
               "port" => "#{s.ServicePort}",
-              "name" => server_name,
+              "name" => deployment_name,
               "type" => server_type }
 
       if server_type == 'POWERDNS'
-        res['mgmt_port'] = ConsulAccess.getKey("digitalrebar/private/dns/#{server_name}/mgmt_port")
-        res['mgmt_token'] = ConsulAccess.getKey("digitalrebar/private/dns/#{server_name}/mgmt_token")
-        res['mgmt_name'] = (ConsulAccess.getKey("digitalrebar/private/dns/#{server_name}/mgmt_name") rescue 'localhost')
+        res['mgmt_port'] = ConsulAccess.getKey("digitalrebar/private/dns/#{deployment_name}/mgmt_port")
+        res['mgmt_token'] = ConsulAccess.getKey("digitalrebar/private/dns/#{deployment_name}/mgmt_token")
+        res['mgmt_name'] = (ConsulAccess.getKey("digitalrebar/private/dns/#{deployment_name}/mgmt_name") rescue 'localhost')
       end
 
       res

--- a/rails/app/models/service.rb
+++ b/rails/app/models/service.rb
@@ -28,6 +28,12 @@ class Service < Role
         count += 1
         break if count > 20
         pieces = ConsulAccess.getService(service_name, :all, options, meta)
+        pieces.select! do |piece|
+          # New-school method of seeing if this service is in the proper deployment
+          piece.ServiceTags.any? do |st|
+            st =~ /^deployment:\s#{nr.deployment.name}$/ || st == nr.deployment.name
+          end
+        end if pieces
         if pieces and pieces.empty?
           Rails.logger.info("#{service_name} not available ... wait 10m or next update")
           runlog << "#{service_name} not available ... wait 10m or next update"


### PR DESCRIPTION
For now, change up how the service model looks for services in Consul
to allow for a more descriptive tag name.

This works with the current naming scheme as well as the next one, so it can be pulled without needing updated containers.