### PR TITLE
Providertweaks2

### DIFF
--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -44,7 +44,12 @@ class ProvidersController < ApplicationController
   end
 
   def show
-    @item = Provider.find_key(params[:id])
+    @item = if params[:id] == 'create'
+      t = params[:new][:type]
+      Provider.new(name: t.downcase, id: -1, type: t, description: I18n.t('not_set'))
+    else
+      Provider.find_key(params[:id])
+    end
     respond_to do |format|
       format.html { render :show  }
       format.json { render api_show @item }

--- a/rails/app/views/nodes/index.html.haml
+++ b/rails/app/views/nodes/index.html.haml
@@ -14,8 +14,7 @@
         = text_field_tag :number, 1, :size => 2
         %button{:onclick=>"add_nodes()"}= t('add')
       - else
-        = link_to ('.no_providers'), providers_path
-
+        = link_to t('.no_providers'), providers_path, :class=>:button
 - if @list.length == 0
   %p= t '.no_nodes'
 - else

--- a/rails/app/views/providers/_awsprovider.html.haml
+++ b/rails/app/views/providers/_awsprovider.html.haml
@@ -10,7 +10,7 @@
     %td= text_field_tag "auth_details[aws_access_key_id]", @item.auth_details['aws_access_key_id'], :size => 30
   %tr
     %td= t 'secret_access_key', :scope=>'providers.show.aws'
-    %td= text_field_tag "auth_details[aws_secret_access_key]", @item.auth_details['aws_secret_access_key'], :size => 60
+    %td= password_field_tag "auth_details[aws_secret_access_key]", @item.auth_details['aws_secret_access_key'], :size => 60
   %tr
     %td= t 'region', :scope=>'providers.show.aws'
     %td= text_field_tag "auth_details[region]", @item.auth_details['region'] || "us-west", :size => 30

--- a/rails/app/views/providers/_googleprovider.html.haml
+++ b/rails/app/views/providers/_googleprovider.html.haml
@@ -10,4 +10,4 @@
     %td= text_field_tag "auth_details[google_project]", @item.auth_details['google_project'], :size => 30
   %tr
     %td= t 'json_key', :scope=>'providers.show.google'
-    %td= text_field_tag "auth_details[google_json_key]", @item.auth_details['google_json_key'], :size => 60
+    %td= password_field_tag "auth_details[google_json_key]", @item.auth_details['google_json_key'], :size => 60

--- a/rails/app/views/providers/_packetprovider.html.haml
+++ b/rails/app/views/providers/_packetprovider.html.haml
@@ -4,7 +4,7 @@
       %img{:src=>"https://www.packet.net/assets/images/logo-main.png", :width=>138}
 %tr
   %td= t 'token', :scope=>'providers.show.packet'
-  %td= text_field_tag("auth_details[project_token]", @item.auth_details['project_token'], :size => 30)
+  %td= password_field_tag("auth_details[project_token]", @item.auth_details['project_token'], :size => 30)
 %tr
   %td= t 'id', :scope=>'providers.show.packet'	
   %td= text_field_tag("auth_details[project_id]", @item.auth_details['project_id'], :size => 30)

--- a/rails/app/views/providers/index.html.haml
+++ b/rails/app/views/providers/index.html.haml
@@ -1,13 +1,19 @@
-- available = {t('.aws')=>"AWSProvider", t('.google')=>"GoogleProvider", t('.iaas')=>"FogProvider", t('.metal')=>'MetalProvider', t('.packet')=>'PacketProvider'}
+- available = {t('.aws')=>"AwsProvider", t('.google')=>"GoogleProvider", t('.iaas')=>"FogProvider", t('.metal')=>'MetalProvider', t('.packet')=>'PacketProvider'}
 
-%h1= t '.title'
+%table{:width=>'100%'}
+  %tr
+    %td
+      %h1= t '.title'
+    %td{:align=>'right'}
+      = form_for :provider, :'data-remote' => true, :url => provider_path(:id=>"create"), :html => { :method=>:get, :'data-type' => 'html',  :class => "formtastic" } do |f|
+        = select :new, :type, options_for_select(available, available.keys.first)
+        = button_tag t(".new"), :method=>:get, :html => {:class=>"button"}
 
 %table.data.box
   %thead
     %th= t '.name'
     %th= t '.type'
     %th= t '.description'
-    %th= ""
   %tbody
     - @list.each do |i|
       - next unless i.type
@@ -15,11 +21,3 @@
         %td= link_to i.name, provider_path(i.id)
         %td= i.type
         %td= i.description
-    = form_for :provider, :'data-remote' => true, :url => providers_path(), :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic" } do |f|
-      %tr
-        %td= text_field_tag :name, t('default'), :size => 15
-        %td= select :type, nil, options_for_select(available, available.keys.first)
-        %td= text_field_tag :description, t('not_set'), :size => 40
-        %td
-          = f.button :type => "submit", :name => "create", :method=>:post, :value => t('.new')
-          = hidden_field_tag :auth_details, "{}"

--- a/rails/app/views/providers/show.html.haml
+++ b/rails/app/views/providers/show.html.haml
@@ -1,23 +1,35 @@
 %h1= t '.title', :name => @item.name.titleize
 
-= form_for :provider, :'data-remote' => true, :url => provider_path(@item.id), :html => { :method=>:put, :'data-type' => 'json',  :class => "formtastic" } do |f|
-  
+- if @item.id < 0
+  - url = providers_path()
+  - method = :post
+- else
+  - url = provider_path(@item.id)
+  - method = :put
+
+= form_for :provider, :'data-remote' => true, :url => url, :html => { :method=>method, :'data-type' => 'json',  :class => "formtastic" } do |f|
+
   %table.data.box
     %thead
       %tr
         %th= link_to t(".name"), providers_path
-        %th= @item.name
+        %th
     %tbody
       %tr
-        %td= t '.type'
-        %td
-          = @item.type || t('not_set') rescue t('not_set' )
-          (
-          = link_to t('raw'), provider_path(@item.id, :raw=>true)
-          )
+        %td= t '.name'
+        %td= text_field_tag :name, @item.name, :size => 25
       %tr
         %td= t '.description'
         %td= text_field_tag :description, @item.description, :size => 50
+      %tr
+        %td= t '.type'
+        %td
+          = hidden_field_tag :type, @item.type
+          = @item.type || t('not_set') rescue t('not_set' )
+          - if @item.id > 0
+            (
+            = link_to t('raw'), provider_path(@item.id, :raw=>true)
+            )
       - begin 
         - if params.include? :raw
           = render :partial => 'show', :locals=>{:item => @item}
@@ -32,7 +44,7 @@
     %tfoot
       %tr
         %td
-        %td= f.button :type => "submit", :name => "update", :method=>:post, :value => t('.update')
+        %td= f.button :type => "submit", :name => "update", :method=>method, :value => t('.update')
 
 %br
 

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -371,7 +371,7 @@ en:
       provider: "Provider"
       create_nodes: "Provider Nodes"
       name_base: "digital_rebar_node"
-      no_providers: "No Drivable Providers"
+      no_providers: "Node Providers"
       create_failed: "Create Failed"
       <<: *deployment_common
       <<: *node_role_states
@@ -477,7 +477,7 @@ en:
       name: "Name"
       description: "Description"
       type: "Type"
-      new: "Create Provider"
+      new: "Add Provider"
       aws: "Amazon AWS"
       google: "Google GCE"
       metal: "Metal Provisioner"
@@ -485,6 +485,7 @@ en:
       iaas: "IaaS Generic - Fog"
     show:
       title: "%{name} Provider"
+      new: "New"
       description: "Description"
       name: "Provider"
       nodes: "Nodes"
@@ -498,6 +499,7 @@ en:
       aws:
         access_key_id: "Access Key"
         secret_access_key: "Secret"
+        region: "Region"
       packet:
         token: "Token"
         id: "ID"


### PR DESCRIPTION
as per @galthaus, changed flow to NOT create DB objects from index.

Instead, users pick a type and the UI creates a stub model for the user.
Only when the user posts, is the provider created.  This prevents hitting the events multiple times when new providers are added.

Updates still work on the same form.

Changes to node index are not that big - it was using Windows line endings?!  Fixed.