### PR TITLE
enable cross site AJAX (in dev for now) using CORS features

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -53,6 +53,8 @@ gem 'json-patch'
 gem 'rbnacl-libsodium'
 # For talking to JSONRPC 2.0 servers via HTTP
 gem 'jsonrpc-client'
+# For AJAX UI, allows Cross Site Reference
+gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   gem 'coveralls'

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -40,8 +40,19 @@ module Rebar
       config.active_support.deprecation = :notify
       config.action_controller.allow_forgery_protection    = true
       config.eager_load = true
-    end
 
+      # enable CORS, in Dev only for now 
+      config.middleware.insert_before 0, Rack::Cors do
+        allow do
+          origins '*' 
+          resource '*',
+            headers: :any,
+            methods: [:get, :post, :put, :delete, :options, :patch, :head]
+        end
+      end
+    
+    end
+    
     # See everything in the log (default is :info)
     config.log_level = :debug
     config.paths['log'] = "/var/log/rebar/#{Rails.env}.log"


### PR DESCRIPTION
CORS sends headers from the server side that tell browsers it OK to allow CSS.  

For developing AJAX queries from a local browser and remote server (e.g. Angular JS) this is helpful.

Needed by @Meshiest 