### PR TITLE
Add AJAX Node Delete (to match node add)

### DIFF
--- a/rails/app/controllers/nodes_controller.rb
+++ b/rails/app/controllers/nodes_controller.rb
@@ -64,7 +64,7 @@ class NodesController < ApplicationController
         node = Node.find_key params[:id]
         nodes = Node.where :id=>node.id
       else
-        nodes = Node.all
+        nodes = Node.non_system
       end
       nodes.each do |n|
         state = n.state

--- a/rails/app/views/nodes/_index.html.haml
+++ b/rails/app/views/nodes/_index.html.haml
@@ -5,10 +5,12 @@
       %th= t '.name'
       %th= t '.address'
       %th= t '.status'
-      %th= t '.admin'
       %th= t '.description'
       %th= link_to t('.provider'), providers_path
       %th= link_to t('.deployment'), deployments_path
+      %th
+        %input{type: "checkbox", class: "node_action", name:"node_action"}
+        = select_tag "act_on_nodes", options_for_select({t(".node_action") => "none", t(".delete") => "delete"}) #, t(".reboot") => "reboot", t(".debug") => "debug"})
   %tbody.nodelist
     -nodes.each do |n|
       - s = n.state
@@ -26,8 +28,12 @@
           = t (n.alive ? ".alive" : ".dead")
           = t (n.available ? ".available" : ".reserved")
           = NodeRole.state_name(s)
-        %td
-          = t 'yes' if n.admin
         %td= n.description
         %td= link_to n.provider.name, provider_path(n.provider.id) rescue t('unknown')
         %td= link_to n.deployment.name, deployment_path(n.deployment.id), :title=>n.deployment.description
+        %td
+          - if n.admin
+            = t '.admin'
+          - else
+            = check_box_tag "node_action_#{n.id}", n.id, false
+

--- a/rails/app/views/nodes/index.html.haml
+++ b/rails/app/views/nodes/index.html.haml
@@ -24,6 +24,39 @@
 
 :javascript
 
+  $(".node_action").change(function() {
+    if (this.checked)
+      $(":checkbox[id^=" + this.name + "]").attr('checked', true);
+    else
+      $(":checkbox[id^=" + this.name + "]").attr('checked', false);
+  })
+
+  $("#act_on_nodes").change(function() {
+    var action = this.value;
+    console.debug("action #{nodes_path()}");
+    $(":checkbox[id^=node_action]").each( function(index, value) {
+      if (value.checked) {
+        console.debug("loop " + action + " on " + value.value);
+        if (action == "delete") {
+          $.ajax({
+            type: 'DELETE',
+            url: "#{nodes_path}/" + value.value + "?format=json"})
+            .fail(function(jqXHR, textStatus, errorThrown) {
+              alert("#{t('.delete_failed')}: " + textStatus + " " + errorThrown)
+            })
+            .done(function() { 
+              value.disabled = true;
+            }
+          );
+        };
+      };
+    });
+    if (action == "delete") { 
+      location.reload(); } 
+    else {
+      this.value = "none"; }
+  });
+
   function add_nodes() {
     var base_name = $("#name").val();
     var provider = $("#add_provider").val();

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -365,7 +365,7 @@ en:
   nodes:
     index:
       title: "Nodes"
-      admin: "Admin?"
+      admin: "N/A (Admin)"
       address: "Address"
       no_nodes: "No Nodes Registered.  Suggested action: configure Rebar."
       provider: "Provider"
@@ -373,6 +373,11 @@ en:
       name_base: "digital-rebar-node"
       no_providers: "Node Providers"
       create_failed: "Create Failed"
+      node_action: "Actions:"
+      delete_failed: "Delete Failed"
+      delete: "Delete"
+      reboot: "Reboot"
+      debug: "Debug"
       <<: *deployment_common
       <<: *node_role_states
     show:


### PR DESCRIPTION
Add checkbox (and all check) to nodes index that allows users to delete nodes.

Uses REST DELETE call behind the scenes.

I did the work so that we could add reboot & debug options in the future.

To make this NOT SUCK, I also fixed the node index refresh bug.