### PR TITLE
CORS Headers for AJAX UX Work

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -314,7 +314,7 @@ class ApplicationController < ActionController::Base
   def cors_headers
     access_control = {
       'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
-      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization', # If-Modified-Since,If-None-Match,
+      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
       'Access-Control-Allow-Credentials' => true,
       'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
     }
@@ -348,7 +348,6 @@ class ApplicationController < ActionController::Base
 
   #return true if we digest signed in
   def rebar_auth
-    Rails.logger.error("ZEHICLE: #{request.headers['HTTP_AUTHORIZATION']}")
     case
     when current_user then authenticate_user!
     when digest_request? then digest_auth!

--- a/rails/app/controllers/support_controller.rb
+++ b/rails/app/controllers/support_controller.rb
@@ -28,14 +28,6 @@ class SupportController < ApplicationController
     render :text=>params[:id]
   end
 
-  def digest
-    if session[:digest_user]
-      render :text => t('user.digest_success', :default=>'success')
-    else
-      render :text => "digest", :status => :unauthorized
-    end
-  end
-
   def fail
     raise I18n.t('chuck_norris')
   end

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -28,7 +28,7 @@ class UsersController < ApplicationController
   def cors_headers
     access_control = {
       'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
-      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie, Authorization', # If-Modified-Since,If-None-Match,
+      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
       'Access-Control-Allow-Credentials' => true,
       'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
     }
@@ -36,7 +36,7 @@ class UsersController < ApplicationController
   end
 
   def digest
-    if request.get? or request.post?
+    if request.get? or request.post? or request.head?
       if request.headers["HTTP_ORIGIN"]
         cors_headers
         user = User.find_key session[:digest_user]
@@ -47,7 +47,7 @@ class UsersController < ApplicationController
         end
       else
         if session[:digest_user]
-          render :text => t('user.digest_success', :default=>'success')
+          render :text => t('user.digest_success', :default=>'success'), :status => :ok
         else
           render :text => "digest", :status => :unauthorized
         end

--- a/rails/app/views/errors/500.html.haml
+++ b/rails/app/views/errors/500.html.haml
@@ -1,4 +1,4 @@
-- style = "#{(!current_user.settings(:errors).expand ? 'display:none; ' : '')}position:relative; top:1em"
+- style = "#{(!current_user.settings(:errors).expand ? 'display:none; ' : '')}position:relative; top:1em" rescue 'display:none;'
 %div#error_500{:class=>"fail box"}
   %div.message
     %h2= t 'error.title'

--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -102,7 +102,7 @@
 
         })
         .fail(function(jqXHR, textStatus, errorThrown) {
-          location.load("/my/users/sign_in");
+          location.load("#{main_app.destroy_user_session_path()}");
         });
 
       } else {

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -46,7 +46,7 @@ module Rebar
         allow do
           origins '*' 
           resource '*',
-            headers: :any,
+            headers: 'Authorization, WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin', #:any,
             methods: [:get, :post, :put, :delete, :options, :patch, :head]
         end
       end

--- a/rails/config/initializers/devise.rb
+++ b/rails/config/initializers/devise.rb
@@ -19,7 +19,7 @@ Devise.setup do |config|
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class with default "from" parameter.
   config.mailer_sender = "please-change-me-at-config-initializers-devise@example.com"
-  config.secret_key = 'b50e5bb6be60b6ec184d4519aaa3678d0598f05f2b10d3bf339695af574102bdea703cdeae17eeebb98630d9be67fb4159c4ae7aa087ac1343334a761cab8c1a'
+  config.secret_key = 'deba5bb6be60b6ec184d4519aaa3678d0598f05f2b10d3bf339695af574102bdea703cdeae17eeebb98630d9be67fb4159c4ae7aa087ac1343334a761cab8c1a'
 
   # Configure the class responsible to send e-mails.
   # config.mailer = "Devise::Mailer"
@@ -73,7 +73,7 @@ Devise.setup do |config|
   config.http_authenticatable = true
 
   # If http headers should be returned for AJAX requests. True by default.
-  # config.http_authenticatable_on_xhr = true
+  config.http_authenticatable_on_xhr = true
 
   # The realm used in Http Basic Authentication. "Application" by default.
   config.http_authentication_realm = 'Rebar'
@@ -224,7 +224,7 @@ Devise.setup do |config|
   # should add them to the navigational formats lists.
   #
   # The "*/*" below is required to match Internet Explorer requests.
-  # config.navigational_formats = ["*/*", :html]
+  config.navigational_formats = ["*/*", :html, :json]
 
   # The default HTTP method used to sign out a resource. Default is :delete.
   config.sign_out_via = :delete

--- a/rails/config/initializers/secret_token.rb
+++ b/rails/config/initializers/secret_token.rb
@@ -4,4 +4,4 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
-Rebar::Application.config.secret_token = '591f1a3e29dfc026c08a286ae5b357aa978b2f810709ad3afaef8cd2ad6726302a5744e349220ad438b1e7ad6233cfd40f24abfebccb1dd6befc9b9ede6467cb'
+Rebar::Application.config.secret_token = Rails.env["SECRET_KEY_BASE"] || 'deba4591f1a3e29dfc026c08a286ae5b357aa978b2f810709ad3afaef8cd2ad6726302a5744e349220ad438b1e7ad6233cfd40f24abfebccb1dd6befc9b9ede6'

--- a/rails/config/initializers/session_store.rb
+++ b/rails/config/initializers/session_store.rb
@@ -14,10 +14,11 @@
 # 
 
 # sessions needed for AJAX CORS
-Rebar::Application.config.force_ssl = true
+Rebar::Application.config.force_ssl = Rails.env.production?
 Rebar::Application.config.session_store :cookie_store,
   key: '_rebar_session',
   secret: "Digtal_Rebar_was_OpenCrowbar",
-  secure: true, # flags cookies as secure only in production
-  httponly: false # should be true by default for all cookies
+  domain: :all,
+  secure: Rails.env.production?,
+  httponly: false
 	    

--- a/rails/config/initializers/session_store.rb
+++ b/rails/config/initializers/session_store.rb
@@ -1,0 +1,23 @@
+# Copyright 2015, RackN 
+# 
+# Licensed under the Apache License, Version 2.0 (the "License"); 
+# you may not use this file except in compliance with the License. 
+# You may obtain a copy of the License at 
+# 
+#  http://www.apache.org/licenses/LICENSE-2.0 
+# 
+# Unless required by applicable law or agreed to in writing, software 
+# distributed under the License is distributed on an "AS IS" BASIS, 
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. 
+# See the License for the specific language governing permissions and 
+# limitations under the License. 
+# 
+
+# sessions needed for AJAX CORS
+Rebar::Application.config.force_ssl = true
+Rebar::Application.config.session_store :cookie_store,
+  key: '_rebar_session',
+  secret: "Digtal_Rebar_was_OpenCrowbar",
+  secure: true, # flags cookies as secure only in production
+  httponly: false # should be true by default for all cookies
+	    

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -137,6 +137,7 @@ Rebar::Application.routes.draw do
 
       # framework resources pattern (not barclamps specific)
       scope 'api' do
+        match '(*session)' => "users#options", via: [:options]
         scope 'status' do
           get "nodes(/:id)" => "nodes#status", :as => :nodes_status
           get "deployments(/:id)" => "deployments#status", :as => :deployments_status
@@ -319,7 +320,7 @@ Rebar::Application.routes.draw do
               put "reset_password"
             end
           end
-          get 'digest'        => "support#digest"
+          match 'digest' => "users#digest", via: [:get, :post, :delete]
         end # version
       end # api
     end # id constraints

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -320,7 +320,7 @@ Rebar::Application.routes.draw do
               put "reset_password"
             end
           end
-          match 'digest' => "users#digest", via: [:get, :post, :delete]
+          match 'digest' => "users#digest", as: :digest_url, via: [:get, :post, :head, :delete]
         end # version
       end # api
     end # id constraints


### PR DESCRIPTION
These changes address Response Headers that are needed by AJAX apps (e.g. Angular) that are called from domains that are not the original domain.   Those require exposing the OPTIONS method.

While we will usually be calling from the same system, this approach makes it easier to develop against multiple DR sites from a single web page. 

Some minor cleanup also 1) move digest into user control (from support) and 2) allow override of secret from env variables for security. 3) name session cookie to be rebar.  4) fix hardcoded path