### PR TITLE
add node_id to attrib return so that UX can find back references

### DIFF
--- a/rails/app/controllers/attribs_controller.rb
+++ b/rails/app/controllers/attribs_controller.rb
@@ -56,6 +56,8 @@ class AttribsController < ApplicationController
     else
       ret = @attrib.as_json
       ret["value"] = @attrib.get(target,bucket)
+      # added node_id so what we can get backwards references if type is node
+      ret["node_id"] = target.is_a?(Node) ? target.id : nil
       respond_to do |format|
         format.html { }
         format.json { render json: ret, content_type: cb_content_type(@attrib, "obj") }


### PR DESCRIPTION
This is needed for the UX work so that we can lookup Node IP Addresses using the nodes/#/attribs api call.