### PR TITLE
Create fast, non-secured path for testing if API is Alive (and provide EULA)

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -351,6 +351,7 @@ class ApplicationController < ActionController::Base
     case
     when current_user then authenticate_user!
     when digest_request? then digest_auth!
+    when request.path == '/api/license' then true  # specialized path for license & URL validation
     when (request.local? ||
           (/^::ffff:127\.0\.0\.1$/ =~ request.remote_ip)) &&
         File.exists?("/tmp/.rebar_in_bootstrap") &&

--- a/rails/app/controllers/docs_controller.rb
+++ b/rails/app/controllers/docs_controller.rb
@@ -29,7 +29,10 @@ class DocsController < ApplicationController
     else
       @text = "#{I18n.t('.topic_missing', :scope=>'docs.topic')}: #{@file}"
     end
-    render :show
+      respond_to do |format|
+        format.html { render :show }
+        format.json { render json: { :eula => @raw } }
+      end
   end
 
 end

--- a/rails/app/controllers/docs_controller.rb
+++ b/rails/app/controllers/docs_controller.rb
@@ -20,19 +20,23 @@ class DocsController < ApplicationController
 
   # render licenses details for login
   def eula
-    @file = Rails.configuration.rebar.eula_base || '../LICENSE.md'
-    if File.exist? @file
-      @raw = IO.read(@file)
-      fix_encoding! unless @raw.valid_encoding?
-      @raw.encode!('UTF-8', :invalid=>:replace)
-      @text = Maruku.new(@raw).to_html
+    if params.has_key? :alive            
+      render json: {}, status => :no_content
     else
-      @text = "#{I18n.t('.topic_missing', :scope=>'docs.topic')}: #{@file}"
-    end
+      @file = Rails.configuration.rebar.eula_base || '../LICENSE.md'
+      if File.exist? @file
+        @raw = IO.read(@file)
+        fix_encoding! unless @raw.valid_encoding?
+        @raw.encode!('UTF-8', :invalid=>:replace)
+        @text = Maruku.new(@raw).to_html
+      else
+        @text = "#{I18n.t('.topic_missing', :scope=>'docs.topic')}: #{@file}"
+      end
       respond_to do |format|
         format.html { render :show }
         format.json { render json: { :eula => @raw } }
       end
+    end
   end
 
 end

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -138,6 +138,7 @@ Rebar::Application.routes.draw do
       # framework resources pattern (not barclamps specific)
       scope 'api' do
         match '(*session)' => "users#options", via: [:options]
+        get 'license' => 'docs#eula'
         scope 'status' do
           get "nodes(/:id)" => "nodes#status", :as => :nodes_status
           get "deployments(/:id)" => "deployments#status", :as => :deployments_status


### PR DESCRIPTION
Looking at the log entries created by Consul health changes, it was clear that "rebar ping" was creating a lot of noise - especially if it was not given valid credentials.

I added a '/api/license?alive" to handle these requests outside of the login.  Without the ?alive flag, it returns the API EULA text (same as /doc/eula) which is already outside of the login domain.

Part of my objective was to make this very quiet logging and also low overhead.

Next step is to add rebar alive to the CLI.