### PR TITLE
Make use-dns default to true to match baremetal installs and

### DIFF
--- a/barclamps/dns.yml
+++ b/barclamps/dns.yml
@@ -135,7 +135,7 @@ attribs:
   - name: use-dns
     description: 'Whether the node should attempt to use the dns service'
     map: 'rebar/providers/use_dns'
-    default: false
+    default: true
     schema:
       type: bool
       required: true


### PR DESCRIPTION
have the providers override when needed.