### PR TITLE
include the node-control-address in the json return

### DIFF
--- a/rails/app/models/node.rb
+++ b/rails/app/models/node.rb
@@ -68,7 +68,9 @@ class Node < ActiveRecord::Base
   def as_json(args = nil)
     args ||= {}
     args[:except] = [ :discovery, :hint, :order, :notes ]
-    super(args)
+    o = super(args)
+    o['node-control-address'] = get_attrib('node-control-address')
+    o
   end
 
   # Get all the attributes applicable to a node.


### PR DESCRIPTION
because we ALWAYS want it.

this one attribute is always needed and makes sense to include in the json model.

otherwise, the UX needs to make a second call for this one attribute all the time.