### PR TITLE
API for node_role?runlog produces less runlog text

### DIFF
--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -62,6 +62,7 @@ class UsersController < ApplicationController
   # CORS header method
   def options
     cors_headers
+    response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,PATCH,HEADERS'
     render :nothing => true, :status => :no_content
   end
 


### PR DESCRIPTION
Will truncate to 80 or whatever value you pass with the parameter.

Unless there's an error.  Then you get the full log for that node_role.

This was needed because we were passing A LOT OF data for the node_roles because of the runlog text.