### PR TITLE
License CORS

### DIFF
--- a/rails/app/controllers/docs_controller.rb
+++ b/rails/app/controllers/docs_controller.rb
@@ -20,6 +20,13 @@ class DocsController < ApplicationController
 
   # render licenses details for login
   def eula
+    access_control = {
+      'Access-Control-Allow-Origin' => request.headers["HTTP_ORIGIN"],
+      'Access-Control-Allow-Headers' => 'X-Requested-With,Content-Type,Cookie,Authorization,WWW-Authenticate', # If-Modified-Since,If-None-Match,
+      'Access-Control-Allow-Credentials' => true,
+      'Access-Control-Expose-Headers' => 'WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin'
+    }
+    access_control.each{ |k, v| response.headers[k] = v } if request.headers["HTTP_ORIGIN"]
     if params.has_key? :alive            
       render json: {}, status => :no_content
     else

--- a/rails/config/initializers/secret_token.rb
+++ b/rails/config/initializers/secret_token.rb
@@ -4,4 +4,6 @@
 # If you change this key, all old signed cookies will become invalid!
 # Make sure the secret is at least 30 characters and all random,
 # no regular words or you'll be exposed to dictionary attacks.
+
+# Use bundle exec rake secret to create a new token
 Rebar::Application.config.secret_token = ENV["SECRET_TOKEN"] || 'deba4591f1a3e29dfc026c08a286ae5b357aa978b2f810709ad3afaef8cd2ad6726302a5744e349220ad438b1e7ad6233cfd40f24abfebccb1dd6befc9b9ede6'


### PR DESCRIPTION
The api/license call is outside of the auth routines where we set CORS.  The UX needed these to be set here too.

At some point, we need to DRY these.