### PR TITLE
it turns out we DONT want the CORS gem if we're setting the headers our self!

### DIFF
--- a/rails/Gemfile
+++ b/rails/Gemfile
@@ -53,8 +53,6 @@ gem 'json-patch'
 gem 'rbnacl-libsodium'
 # For talking to JSONRPC 2.0 servers via HTTP
 gem 'jsonrpc-client'
-# For AJAX UI, allows Cross Site Reference
-gem 'rack-cors', :require => 'rack/cors'
 
 group :development, :test do
   gem 'coveralls'

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -62,7 +62,7 @@ class UsersController < ApplicationController
   # CORS header method
   def options
     cors_headers
-    response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,PATCH,HEADERS'
+    response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,OPTIONS,PATCH,HEAD'
     render :nothing => true, :status => :no_content
   end
 

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -42,15 +42,6 @@ module Rebar
       config.eager_load = true    
     end
     
-        # enable CORS, in Dev only for now 
-    config.middleware.insert_before 0, Rack::Cors do
-      allow do
-        origins '*' 
-        resource '*',
-          headers: 'Authorization, WWW-Authenticate, Set-Cookie, Access-Control-Allow-Headers, Access-Control-Allow-Credentials, Access-Control-Allow-Origin', #:any,
-          methods: [:get, :post, :put, :delete, :options, :patch, :head]
-      end
-    end
 
     # See everything in the log (default is :info)
     config.log_level = :debug

--- a/rails/config/initializers/session_store.rb
+++ b/rails/config/initializers/session_store.rb
@@ -14,11 +14,11 @@
 # 
 
 # sessions needed for AJAX CORS
-Rebar::Application.config.force_ssl = Rails.env.production?
+Rebar::Application.config.force_ssl = true
 Rebar::Application.config.session_store :cookie_store,
   key: '_rebar_session',
   secret: "Digtal_Rebar_was_OpenCrowbar",
   domain: :all,
-  secure: Rails.env.production?,
+  secure: true,
   httponly: false
 	    


### PR DESCRIPTION
The CORS gem config was conflicting w/ our own headers.

Removed it and references.

Also, we always use secure.