### PR TITLE
Adjust consul to handle attribute look-ups.  The empty value

### DIFF
--- a/chef/cookbooks/consul/recipes/start-service.rb
+++ b/chef/cookbooks/consul/recipes/start-service.rb
@@ -31,7 +31,7 @@ case node[:consul][:service_mode]
 when 'server'
   copy_params << :bootstrap_expect
   service_config['server'] = true
-  service_config['retry_join'] = node[:consul][:servers]
+  service_config['retry_join'] = node[:consul][:servers] - ["[#{node[:consul][:bind_addr]}]:8301"]
 when 'client'
   service_config['retry_join'] = node[:consul][:servers]
 else

--- a/rails/app/models/barclamp_consul/consul_master.rb
+++ b/rails/app/models/barclamp_consul/consul_master.rb
@@ -27,12 +27,10 @@ class BarclampConsul::ConsulMaster < Role
       consuls = NodeRole.where(deployment_id: nr.deployment_id, role_id: nr.role_id).to_a
 
       servers = consuls.map{|cnr| "[#{cnr.node.addresses.first.addr}]:8301"}
-      to_join = consuls.reject{|cnr|cnr.id == nr.id}.map{|cnr| "[#{cnr.node.addresses.first.addr}]:8301"}
       Rails.logger.info("Updating global Consul servers: #{servers.inspect}")
-      Rails.logger.info("Updating this Consul's servers: #{to_join.inspect}")
       Attrib.set("consul-servers",nr.deployment_role,servers)
       Attrib.set("consul-bootstrap-expect",nr.deployment_role,servers.length)
-      Attrib.set_without_save("consul-servers",nr,to_join)
     end
+    true
   end
 end

--- a/rails/app/models/barclamp_consul/consul_member.rb
+++ b/rails/app/models/barclamp_consul/consul_member.rb
@@ -23,5 +23,6 @@ class BarclampConsul::ConsulMember < Role
         Attrib.set_without_save("consul-address",nr,nr.node.addresses.first.addr)
       end
     end
+    true
   end
 end


### PR DESCRIPTION
breaks the single consul master setup.  Multiple nodes would
work because the clients would get the servers partial list
and start up anyway.