### PR TITLE
GCE nested json should NOT be treated as a string

### DIFF
--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -58,7 +58,14 @@ class ProvidersController < ApplicationController
 
   def update
     # deal w/ non-json form data from UI
-    params[:auth_details] = params[:auth_details].to_json if params[:auth_details].is_a? Hash
+    if params[:auth_details].is_a? Hash
+      # if we're passing JSON then we need to convert that to a nested hash (ASSUME json params have json in the title)
+      params[:auth_details].each do |key, value|
+        params[:auth_details][key] = JSON.parse(value) if key =~ /json/ or key.start_with?("{")
+      end
+      # turn the hash into json for the provider
+      params[:auth_details] = params[:auth_details].to_json
+    end
     Provider.transaction do
       @item = Provider.find_key(params[:id]).lock!
       if request.patch?

--- a/rails/app/views/providers/_googleprovider.html.haml
+++ b/rails/app/views/providers/_googleprovider.html.haml
@@ -10,4 +10,6 @@
     %td= text_field_tag "auth_details[google_project]", @item.auth_details['google_project'], :size => 30
   %tr
     %td= t 'json_key', :scope=>'providers.show.google'
-    %td= password_field_tag "auth_details[google_json_key]", @item.auth_details['google_json_key'], :size => 60
+    %td
+      %textarea{:name => "auth_details[google_json_key]", :rows=>20, :cols=>160}
+        = @item.auth_details['google_json_key'] || "{ 'replace_me':'with exact json from GCE' }'"


### PR DESCRIPTION
GCE requires a JSON hash for credentials.  The previous code was turning that into a string (and not displaying it well).

This code will generically detect JSON inside the auth_details set and build correct JSON with nested inputs.

This does NOT apply to the API - it only matters for puts that use the form builder hash as input.  A normal JSON string is not reviewed.