### PR TITLE
show less google json to hide the key

### DIFF
--- a/rails/app/views/providers/_googleprovider.html.haml
+++ b/rails/app/views/providers/_googleprovider.html.haml
@@ -11,5 +11,5 @@
   %tr
     %td= t 'json_key', :scope=>'providers.show.google'
     %td
-      %textarea{:name => "auth_details[google_json_key]", :rows=>20, :cols=>160}
+      %textarea{:name => "auth_details[google_json_key]", :rows=>5, :cols=>160}
         = JSON.pretty_generate (@item.auth_details['google_json_key'] || { 'replace_me' => 'with exact json from GCE' } )


### PR DESCRIPTION
a little more privacy for sensitive information.
could not find a simpler way to obscure the data