### PR TITLE
Fix for Issue 1067 (RS Wizard not updated for new network naming pattern)

### DIFF
--- a/rails/app/models/deployment.rb
+++ b/rails/app/models/deployment.rb
@@ -41,7 +41,7 @@ class Deployment < ActiveRecord::Base
   has_many        :node_roles,        :dependent => :destroy
   has_many        :nodes
   belongs_to      :parent,            class_name: "Deployment"
-  has_many        :networks
+  has_many        :networks,          :dependent => :destroy
 
   scope           :children_of,     ->(d)  { where(:parent_id => d.id) }
 


### PR DESCRIPTION
Related to #1067 - the RS Wizard creates networks (the Barclamp Wizards do not) that have to comply to the two part category-group naming pattern.  

Also, the wizard assumes that the user is smart about host ranges.  Now if the user creates a duplicate, we continue anyway.

Also corrected missing delete dependency on deployment destroy