### PR TITLE
Noderole should not use find key

### DIFF
--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -56,6 +56,7 @@ class NodeRolesController < ApplicationController
       deployments = Deployment.all.map{ |d| d.id }
       out[:deleted][:deployments] = (params[:deployments] - deployments) rescue []
     end
+    Rails.logger.warn("ZEHICLE active #{out.inspect}")
 
     # done
     render api_array out.to_json
@@ -103,7 +104,7 @@ class NodeRolesController < ApplicationController
       raise "could not find role #{params[:id]}" unless role
       @node_role = NodeRole.find_by!(node_id: node.id, role_id: role.id)
     else
-      @node_role = NodeRole.find_key params[:id]
+      @node_role = NodeRole.find params[:id]
     end
     respond_to do |format|
       format.html {  }

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -56,7 +56,6 @@ class NodeRolesController < ApplicationController
       deployments = Deployment.all.map{ |d| d.id }
       out[:deleted][:deployments] = (params[:deployments] - deployments) rescue []
     end
-    Rails.logger.warn("ZEHICLE active #{out.inspect}")
 
     # done
     render api_array out.to_json

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -160,7 +160,7 @@ class NodeRolesController < ApplicationController
                        NodeRole.find_by!(node_id: node.id, role_id: role.id).lock!
                      end
                    else
-                     NodeRole.find_key(key).lock!
+                     NodeRole.find(key).lock!
                    end
       # if you've been passed data then save it
       if request.patch?
@@ -179,7 +179,7 @@ class NodeRolesController < ApplicationController
   end
 
   def destroy
-    @node_role = NodeRole.find_key (params[:id] || params[:node_role_id])
+    @node_role = NodeRole.find (params[:id] || params[:node_role_id])
     @node_role.destroy
     respond_to do |format|
       format.html { redirect_to deployment_path(@node_role.deployment_id) }
@@ -188,7 +188,7 @@ class NodeRolesController < ApplicationController
   end
 
   def propose
-    @node_role = NodeRole.find_key params[:node_role_id]
+    @node_role = NodeRole.find params[:node_role_id]
     @node_role.propose!
     respond_to do |format|
       format.html { redirect_to node_role_path(@node_role.id) }
@@ -197,7 +197,7 @@ class NodeRolesController < ApplicationController
   end
 
   def commit
-    @node_role = NodeRole.find_key params[:node_role_id]
+    @node_role = NodeRole.find params[:node_role_id]
     @node_role.commit!
     respond_to do |format|
       format.html { redirect_to node_role_path(@node_role.id) }
@@ -207,7 +207,7 @@ class NodeRolesController < ApplicationController
 
   def retry
     params[:id] ||= params[:node_role_id]
-    @node_role = NodeRole.find_key params[:id]
+    @node_role = NodeRole.find params[:id]
     @node_role.todo!
     respond_to do |format|
       format.html { redirect_to node_role_path(@node_role.id) }


### PR DESCRIPTION
The find_key method assumes that you can use name as a backup for ID.  That was causing errors when the item was not found (500) instead of 404 issues.

Since NodeRole APIs use the ID, we want to just use the built in Find method.

This is needed because the UX needs to get 404 back when an item does not exist.