### PR TITLE
provide node_role parent and child information for UX via API

### DIFF
--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -214,6 +214,16 @@ class NodeRolesController < ApplicationController
     end
   end
 
+  def parents
+    @node_role = NodeRole.find params[:node_role_id]
+    render api_index NodeRole, @node_role.parents
+  end
+
+  def children
+    @node_role = NodeRole.find params[:node_role_id]
+    render api_index NodeRole, @node_role.children
+  end
+
   def anneal
     respond_to do |format|
       format.html { }

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -296,6 +296,8 @@ Rebar::Application.routes.draw do
             put :retry
             put :propose
             put :commit
+            get :parents
+            get :children
             resources :attribs
           end
           resources :roles do


### PR DESCRIPTION
This information was not readily accessible anywhere else
It is READ ONLY from the API