### PR TITLE
Fix up dhcp service naming

### DIFF
--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -27,8 +27,6 @@ roles:
     jig: role-provided
     flags:
       - service
-    requires:
-      - rebar-api_service
     wants-attribs:
       - rebar-api-servers
     attribs:

--- a/rails/app/models/barclamp_dhcp/service.rb
+++ b/rails/app/models/barclamp_dhcp/service.rb
@@ -16,7 +16,7 @@
 class BarclampDhcp::Service < Service
 
   def do_transition(nr, data)
-    wait_for_service(nr,data, "dhcp")
+    wait_for_service(nr,data, "dhcp-service")
     deployment_role = nr.deployment_role
     until Attrib.get('dhcp_servers',deployment_role) do
       sleep 1


### PR DESCRIPTION
This should be pulled when the service self-registration PR in digitalrebar-deploy is pulled.