### PR TITLE
Add a flag for roles to keep the runlog on rerun.

### DIFF
--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -190,6 +190,7 @@ class Barclamp < ActiveRecord::Base
                              :service=>flags.include?('service'),
                              :cluster=>flags.include?('cluster'),
                              :powersave=>flags.include?('powersave'),
+                             :leaverunlog=>flags.include?('leaverunlog'),
                              :metadata=>role_metadata,
                              :icon=>icon)
         prerequisites.each do |rr|

--- a/rails/app/models/node_role.rb
+++ b/rails/app/models/node_role.rb
@@ -584,7 +584,11 @@ class NodeRole < ActiveRecord::Base
         raise InvalidTransition.new(self,state,TRANSITION)
       end
       Rails.logger.info("NodeRole: Transitioning #{name}")
-      update!(state: TRANSITION, runlog: "")
+      if role.leaverunlog
+        update!(state: TRANSITION)
+      else
+        update!(state: TRANSITION, runlog: "")
+      end
     end
   end
 

--- a/rails/app/models/run.rb
+++ b/rails/app/models/run.rb
@@ -90,7 +90,7 @@ class NodeRoleRun < Que::Job
     rescue StandardError => e
       to_error = true
       NodeRole.transaction do
-        nr.update!(runlog: "#{e.class.name}: #{e.message}\nBacktrace:\n#{e.backtrace.join("\n")}")
+        nr.update!(runlog: "#{nr.runlog}\n\n\n#{e.class.name}: #{e.message}\nBacktrace:\n#{e.backtrace.join("\n")}")
       end
       Rails.logger.info("Run: Queued job #{job.id} for #{nr.name} failed, exceptions raised.")
       Rails.logger.error("#{e.class.name}: #{e.message}\nBacktrace:\n#{e.backtrace.join("\n")}")

--- a/rails/db/migrate/20160303150800_add_leaverunlog.rb
+++ b/rails/db/migrate/20160303150800_add_leaverunlog.rb
@@ -1,0 +1,23 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+class AddLeaverunlog < ActiveRecord::Migration
+
+  def change
+    change_table :roles do |t|
+      t.boolean     :leaverunlog,         null: false, default: false
+    end
+  end
+
+end


### PR DESCRIPTION
When a role takes an exception.  Print the current
runlog along with the exception.  Gives better hints