### PR TITLE
update dev mode based on container startup process

### DIFF
--- a/rails/app/views/layouts/application.html.haml
+++ b/rails/app/views/layouts/application.html.haml
@@ -1,7 +1,10 @@
 !!!
 %html
   %head
-    %title= t 'title', default: "Digital Rebar"
+    %title
+      = t 'title', default: "Digital Rebar"
+      - if Rails.configuration.rebar.devmode
+        = "[dev]"
     = csrf_meta_tags
     = stylesheet_link_tag Rails.configuration.rebar.sass_base || 'application'
     /[if IE]
@@ -62,6 +65,8 @@
       %a{:href=>"https://github.com/orgs/digitalrebar/people", :target=>"_new", :alt=>"Digital Rebar"}
         Digital Rebar
       =t 'version', :version=>Rails.configuration.rebar.version || '2.x'
+      - if Rails.configuration.rebar.devmode
+        = "[dev]"
 
 - if current_user or session[:digest_user]
   :javascript

--- a/rails/config/application.rb
+++ b/rails/config/application.rb
@@ -30,24 +30,26 @@ module Rebar
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.
+    config.rebar = ActiveSupport::OrderedOptions.new
 
-    # do not load if dev file exists
-    unless File.exists? '/tmp/development.txt'
-      # defaults are producction
+    # dev settings if dev file exists
+    if File.exists? '/opt/digitalrebar/dev.mode'
+      config.log_level = :debug
+      config.rebar.devmode = true
+    else
+      # defaults are production
       config.cache_classes = true
       config.action_controller.perform_caching             = true
       config.action_view.cache_template_loading            = true
       config.active_support.deprecation = :notify
       config.action_controller.allow_forgery_protection    = true
       config.eager_load = true    
+      config.log_level = :info
+      config.rebar.devmode = false
     end
     
+    config.paths['log'] = "/var/log/rebar/production.log"
 
-    # See everything in the log (default is :info)
-    config.log_level = :debug
-    config.paths['log'] = "/var/log/rebar/#{Rails.env}.log"
-
-    config.rebar = ActiveSupport::OrderedOptions.new 
     config.rebar.version = '2.E'
     config.rebar.docs = "https://github.com/digitalrebar/doc/blob/master/README.rst"
     config.rebar.chat_link = "https://gitter.im/digitalrebar/core"

--- a/tools/da-lib.sh
+++ b/tools/da-lib.sh
@@ -179,7 +179,7 @@ bring_up_admin_containers() {
     docker-compose up -d
     # enable development mode
     if [ "$DEV_MODE" == "Y" ] ; then
-        docker exec -it compose_rebar_api_1 touch /tmp/development.txt
+        docker exec -it compose_rebar_api_1 touch /opt/digitalrebar/dev.mode
         echo "Starting in DEVELOPMENT MODE"
     fi
 }


### PR DESCRIPTION
Had to move the dev file from /tmp since we don't restart the service but restart the container.

Since devmode is so non-invasive now, changed the default logging to INFO
You can easily set dev.mode file and increase log level if you want.

NOTE: Need to update the docs when this pull goes in!