### PR TITLE
Separate the dns and dns-mgmt service.

### DIFF
--- a/tools/da-lib.sh
+++ b/tools/da-lib.sh
@@ -50,7 +50,7 @@ converge() {
     return 1
 }
 
-known_containers=(provisioner dhcp ntp dns chef webproxy logging debug node access ux)
+known_containers=(provisioner dhcp ntp dns dns-mgmt chef webproxy logging debug node access ux)
 
 declare -A containers
 
@@ -62,6 +62,7 @@ docker_admin_default_containers() {
     [[ ${containers["provisioner"]} ]] || containers["provisioner"]=true
     [[ ${containers["dhcp"]} ]] || containers["dhcp"]=true
     [[ ${containers["dns"]} ]] || containers["dns"]=true
+    [[ ${containers["dns-mgmt"]} ]] || containers["dns-mgmt"]=true
     [[ ${containers["ntp"]} ]] || containers["ntp"]=true
     [[ ${containers["chef"]} ]] || containers["chef"]=true
     [[ ${containers["webproxy"]} ]] || containers["webproxy"]=true


### PR DESCRIPTION
They run the same container different services.