### PR TITLE
Centralize event handling, and expose it via API.

### DIFF
--- a/barclamps/chef.yml
+++ b/barclamps/chef.yml
@@ -61,6 +61,17 @@ roles:
       - proxy-client
     flags:
       - implicit
+    events:
+      - endpoint: inproc://role:chef-client/on_node_delete
+        selectors:
+          - event: on_node_delete
+            obj_class: role
+            obj_id: chef-client
+      - endpoint: inproc://role:chef-client/sync_on_todo
+        selectors:
+          - event: sync_on_todo
+            obj_class: role
+            obj_id: chef-client
     wants-attribs:
       - chef-servers
   - name: chef-solo

--- a/barclamps/consul.yml
+++ b/barclamps/consul.yml
@@ -31,6 +31,12 @@ roles:
       - rebar-installed-node
     flags:
       - implicit
+    events:
+      - endpoint: inproc://role:consul-config/on_deployment_create
+        selectors:
+          - event: on_deployment_create
+            obj_class: role
+            obj_id: consul-config
     attribs:
       - name: consul-disable-remote-exec
         description: 'Whether Consul is allowed to remotel execute programs'
@@ -139,6 +145,12 @@ roles:
       - consul-member
     provides:
       - consul
+    events:
+      - endpoint: inproc://role:consul-master/sync_on_todo
+        selectors:
+          - event: sync_on_todo
+            obj_class: role
+            obj_id: consul-master
     wants-attribs:
       - consul-acl-down-policy
       - consul-acl-default-policy
@@ -203,4 +215,10 @@ roles:
       - consul-master
     provides:
       - consul
-
+    events:
+      - endpoint: inproc://role:consul-member/sync_on_todo
+        selectors:
+          - event: sync_on_todo
+            obj_class: role
+            obj_id: consul-member
+            

--- a/barclamps/dhcp.yml
+++ b/barclamps/dhcp.yml
@@ -40,6 +40,30 @@ roles:
     jig: role-provided
     flags:
       - service
+    events:
+      - endpoint: inproc://role:dhcp-mgmt_service/on_active
+        selectors:
+          - event: on_active
+            obj_class: role
+            obj_id: dhcp-mgmt_service
+      - endpoint: inproc://role:dhcp-mgmt_service/on_node_change
+        selectors:
+          - event: on_node_change
+      - endpoint: inproc://role:dhcp-mgmt_service/on_network_create
+        selectors:
+          - event: on_network_create
+      - endpoint: inproc://role:dhcp-mgmt_service/on_network_change
+        selectors:
+          - event: on_network_change
+      - endpoint: inproc://role:dhcp-mgmt_service/on_network_delete
+        selectors:
+          - event: on_network_delete
+      - endpoint: inproc://role:dhcp-mgmt_service/on_network_allocation_create
+        selectors:
+          - event: on_network_allocation_create
+      - endpoint: inproc://role:dhcp-mgmt_service/on_network_allocation_delete
+        selectors:
+          - event: on_network_allocation_delete
     attribs:
       - name: dhcp-management-servers
         description: 'DHCP Management servers that all Rebar admins should use'

--- a/barclamps/dns.yml
+++ b/barclamps/dns.yml
@@ -69,6 +69,21 @@ roles:
   - name: dns-mgmt_service
     jig: role-provided
     icon: local_library
+    events:
+      - endpoint: inproc://role:dns-mgmt_service/on_active
+        selectors:
+          - event: on_active
+            obj_class: role
+            obj_id: dns-mgmt_service
+      - endpoint: inproc://role:dns-mgmt_service/on_node_change
+        selectors:
+          - event: on_node_change
+      - endpoint: inproc://role:dns-mgmt_service/on_network_allocation_create
+        selectors:
+          - event: on_network_allocation_create
+      - endpoint: inproc://role:dns-mgmt_service/on_network_allocation_delete
+        selectors:
+          - event: on_network_allocation_delete
     flags:
       - service
     attribs:

--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -27,6 +27,13 @@ roles:
     jig: role-provided
     flags:
       - service
+    events:
+      - endpoint: inproc://role:provisioner-service/on_node_delete
+        selectors:
+          - event: on_node_delete
+      - endpoint: inproc://role:provisioner-service/on_node_change
+        selectors:
+          - event: on_node_change
     attribs:
       - name: provisioner-default-os
         description: 'The default operating system the provisioner will deploy'
@@ -147,6 +154,16 @@ roles:
                   required: true
   - name: provisioner-docker-setup
     jig: chef
+    events:
+      - endpoint: inproc://role:provisioner-docker-setup/on_node_create
+        selectors:
+          - event: on_node_create
+      - endpoint: inproc://role:provisioner-docker-setup/on_node_change
+        selectors:
+          - event: on_node_change
+      - endpoint: inproc://role:provisioner-docker-setup/on_node_delete
+        selectors:
+          - event: on_node_delete
     conflicts:
       - rebar-docker-node
     requires:
@@ -174,6 +191,17 @@ roles:
   - name: provisioner-os-install
     jig: script
     icon: present_to_all
+    events:
+      - endpoint: inproc://role:provisioner-os-install/on_todo
+        selectors:
+          - event: on_todo
+            obj_class: role
+            obj_id: provisioner-os-install
+      - endpoint: inproc://role:provisioner-os-install/on_active
+        selectors:
+          - event: on_active
+            obj_class: role
+            obj_id: provisioner-os-install
     requires:
       - rebar-hardware-configured
     flags:

--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -192,6 +192,11 @@ roles:
     jig: script
     icon: present_to_all
     events:
+      - endpoint: inproc://role:provisioner-os-install/on_deployment_create
+        selectors:
+          - event: on_deployment_create
+            obj_class: role
+            obj_id: provisioner-os-install
       - endpoint: inproc://role:provisioner-os-install/on_todo
         selectors:
           - event: on_todo

--- a/barclamps/proxy.yml
+++ b/barclamps/proxy.yml
@@ -28,6 +28,13 @@ roles:
     jig: chef
     requires:
       - consul
+    events:
+      - endpoint: inproc://role:proxy-server/on_network_create
+        selectors:
+          - event: on_network_create
+      - endpoint: inproc://role:proxy-server/on_network_delete
+        selectors:
+          - event: on_network_delete
     attribs:
       - name: proxy-upstream_proxy
         description: "The upstream Web proxy that the proxy on the system will use"
@@ -66,6 +73,13 @@ roles:
                   pattern: '/\Ahttp:\/\/.+\z/'
   - name: proxy-client
     jig: script
+    events:
+      - endpoint: inproc://role:proxy-client/on_network_allocation_create
+        selectors:
+          - event: on_network_allocation_create
+      - endpoint: inproc://role:proxy-client/on_network_allocation_delete
+        selectors:
+          - event: on_network_allocation_delete
     flags:
       - implicit
     wants-attribs:

--- a/barclamps/saltstack.yml
+++ b/barclamps/saltstack.yml
@@ -40,6 +40,15 @@ roles:
       - cluster
     requires:
       - rebar-installed-node
+    events:
+      - endpoint: inproc://role:saltstack-master/on_proposed
+        selectors:
+          - event: on_proposed
+            obj_class: role
+            obj_id: saltstack-master
+      - endpoint: inproc://role:saltstack-master/on_proposed
+        selectors:
+          - event: on_node_delete
     attribs:
       - name: saltstack-master_ip
         description: 'IP that minions should use to talk to the SaltStack Master'
@@ -69,6 +78,12 @@ roles:
       - rebar-installed-node
     flags:
       - implicit
+    events:
+      - endpoint: inproc://role:saltstack-minion/on_active
+        selectors:
+          - event: on_active
+            obj_class: role
+            obj_id: saltstack-minion
     attribs:
       - name: saltstack-minion_public_key
         description: 'Public Key of Minioin'

--- a/rails/app/controllers/event_selectors_controller.rb
+++ b/rails/app/controllers/event_selectors_controller.rb
@@ -1,0 +1,82 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class EventSelectorsController < ApplicationController
+
+
+  def sample
+    render api_sample(EventSelector)
+  end
+
+  def match
+    attrs = EventSelector.attribute_names.map{|a|a.to_sym}
+    objs = []
+    ok_params = params.permit(attrs)
+    objs = EventSelector.where(ok_params) if !ok_params.empty?
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index EventSelector, objs }
+    end
+  end
+
+    # API GET /api/v2/hammers
+  def index
+    @event_selectors = if params.key(:event_sink_id)
+                         EventSink.find_key(params[:event_sink_id]).event_selectors
+                       else
+                         EventSelector.all
+                       end
+    respond_to do |format|
+      format.html { } 
+      format.json { render api_index EventSelector, @event_selectors }
+    end
+  end
+
+  def show
+    @event_selector = EventSelector.find_key(params[:id])
+    respond_to do |format|
+      format.html {  }
+      format.json { render api_show @event_selector }
+    end
+  end
+
+  def update
+    EventSelector.transaction do
+      @event_selector= event.find_key(params[:id]).lock!
+      if request.patch?
+        patch(@event_selector,%w{selector})
+      else
+        @event_selector.update_attributes!(params.permit(:selector))
+      end
+    end
+    render api_show @event_selector
+  end
+
+  def create
+    params.require(:event_sink_id)
+    params.require(:selector)
+    EventSelector.transaction do
+      @event_selector = EventSelector.create!(params.permit(:envent_sink_id,
+                                                    :selector))
+    end
+    render api_show @event_selector
+  end
+
+  def destroy
+    render api_delete EventSelector
+  end
+
+
+end

--- a/rails/app/controllers/event_sinks_controller.rb
+++ b/rails/app/controllers/event_sinks_controller.rb
@@ -1,0 +1,83 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class EventSinksController < ApplicationController
+
+
+  def sample
+    render api_sample(EventSink)
+  end
+
+  def match
+    attrs = EventSink.attribute_names.map{|a|a.to_sym}
+    objs = []
+    ok_params = params.permit(attrs)
+    objs = EventSink.where(ok_params) if !ok_params.empty?
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Event, objs }
+    end
+  end
+
+    # API GET /api/v2/hammers
+  def index
+    @event_sinks = EventSink.all
+    respond_to do |format|
+      format.html { } 
+      format.json { render api_index EventSink, @event_sinks }
+    end
+  end
+
+  def show
+    @event_sink = EventSink.find_key(params[:id])
+    respond_to do |format|
+      format.html {  }
+      format.json { render api_show @event_sink }
+    end
+  end
+
+  def update
+    EventSink.transaction do
+      @event_sink= event.find_key(params[:id]).lock!
+      if request.patch?
+        patch(@event_sink,%w{endpoint username authenticator})
+      else
+        @event_sink.update_attributes!(params.permit(:endpoint,
+                                                :username,
+                                                :authenticator,
+                                                :notes))
+      end
+    end
+    render api_show @event_sink
+  end
+
+  def create
+    params.require(:name)
+    params.require(:endpoint)
+    EventSink.transaction do
+      @event_sink = EventSink.create!(params.permit(:endpoint,
+                                               :username,
+                                               :authenticator,
+                                               :notes))
+    end
+    render api_show @event_sink
+  end
+
+  def destroy
+    render api_delete EventSink
+  end
+
+
+end

--- a/rails/app/controllers/events_controller.rb
+++ b/rails/app/controllers/events_controller.rb
@@ -1,0 +1,56 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+#
+class EventsController < ApplicationController
+
+
+  def sample
+    render api_sample(Event)
+  end
+
+  def match
+    attrs = Event.attribute_names.map{|a|a.to_sym}
+    objs = []
+    ok_params = params.permit(attrs)
+    objs = Event.where(ok_params) if !ok_params.empty?
+    respond_to do |format|
+      format.html {}
+      format.json { render api_index Event, objs }
+    end
+  end
+
+    # API GET /api/v2/hammers
+  def index
+    @events = Event.all
+    respond_to do |format|
+      format.html { } 
+      format.json { render api_index Event, @events }
+    end
+  end
+
+  def show
+    @event = Event.find_key(params[:id])
+    respond_to do |format|
+      format.html {  }
+      format.json { render api_show @event }
+    end
+  end
+
+  def destroy
+    render api_delete Event
+  end
+
+
+end

--- a/rails/app/models/deployment_role.rb
+++ b/rails/app/models/deployment_role.rb
@@ -130,13 +130,12 @@ class DeploymentRole < ActiveRecord::Base
   def role_create_hook
     return if @created
     @created = true
-    Rails.logger.info("Running on_deployment_create hook for #{role.name}")
-    role.on_deployment_create(self)
+    Event.fire(self, obj_class: 'role', obj_id: role.name, event: 'on_deployment_create')
   end
 
   def role_delete_hook
     return false unless noderoles.count == 0
-    role.on_deployment_delete(self)
+    Event.fire(self, obj_class: 'role', obj_id: role.name, event: 'on_deployment_delete')
   end
 
 end

--- a/rails/app/models/event.rb
+++ b/rails/app/models/event.rb
@@ -1,0 +1,47 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'securerandom'
+class Event < ActiveRecord::Base
+
+  def self.fire(obj, params)
+    evt = Event.create!(params: params,
+                        target_class: obj.class.name,
+                        target: obj.to_json)
+    evt.run(obj)
+  end
+
+  def run(obj)
+    Rails.logger.info("Event: event #{id} fired with params #{params.to_json}")
+    wherefrags = []
+    params.each do |k,v|
+      wherefrags << "(event_selectors.selector @> '#{ {k.to_s => v}.to_json}'::jsonb)"
+    end
+    res = []
+    # This needs to handle wildcard subscriptions and more complex
+    # logic at some point in the future, but for now, straight
+    # equality matching will do.
+    matched_selectors = EventSelector.where(wherefrags.join(" AND ")).order(:id).distinct
+    self.event_selectors = matched_selectors.all.map{|es| es.uuid}
+    self.save!
+    matched_selectors.each do |ms|
+      es = ms.event_sink
+      Rails.logger.info("Event: #{params} matched #{ms.selector}")
+      Rails.logger.info("Event: calling #{es.endpoint} for #{ms.selector} with #{obj.inspect}")
+      res << es.run(obj, ms.selector)
+    end
+    return res
+  end
+end

--- a/rails/app/models/event_selector.rb
+++ b/rails/app/models/event_selector.rb
@@ -1,0 +1,26 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class EventSelector < ActiveRecord::Base
+
+  validate :check_selector_sanity
+  belongs_to :event_sink
+
+  private
+
+  def check_selector_sanity
+    errors.add("Selector missing required key #{k}") unless selector.key?('event')
+  end
+end

--- a/rails/app/models/event_sink.rb
+++ b/rails/app/models/event_sink.rb
@@ -1,0 +1,77 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class EventSink < ActiveRecord::Base
+
+  validate :check_endpoint_sanity
+  has_many :event_selectors
+
+  def self.name_column
+    return :endpoint
+  end
+
+  def endpoint_method
+    endpoint.partition('://')[0]
+  end
+  
+  def run(obj, selector)
+    meth, _, rest = endpoint.partition("://")
+    case meth
+    when 'inproc'
+      objklass, _, methpart = rest.partition(':')
+      case objklass
+      when 'role'
+        objname, _ ,methname = methpart.partition('/')
+        runobj = Role.find_key(objname)
+        meth_sym = methname.to_sym
+        runobj.send(meth_sym, obj)
+      else
+        raise "EventSink.run for inproc:// only handles Role hooks for now"
+      end
+    else
+      raise "Event handling method #{method} not implemented"
+    end
+  end
+
+  private
+
+  def check_endpoint_sanity
+    method, sep, rest  = endpoint.partition('://')
+    errors.add("Malformed endpoint #{endpoint}") if sep != '://'
+    case method
+    when 'inproc' then
+      objklass, _, methpart = rest.partition(':')
+      case objklass
+      when 'role'
+        objname, _ ,methname = methpart.partition('/')
+        runobj = (Role.find_key(objname) rescue nil)
+        if runobj
+          meth_sym = methname.to_sym
+          unless runobj.respond_to?(meth_sym)
+            errors.add("Role #{objname} does not respond to #{methname}")
+          end
+        else
+          errors.add("No such role #{objname}")
+        end
+      else
+        errors.add("inproc:// only handles roles for now")
+      end
+    else
+      errors.add("Event handling method #{method} not supported yet")
+    end
+  end
+
+
+end

--- a/rails/app/models/network_allocation.rb
+++ b/rails/app/models/network_allocation.rb
@@ -58,11 +58,7 @@ class NetworkAllocation < ActiveRecord::Base
     # Call all role on_network_allocation_delete hooks with self.
     # These should happen synchronously.
     # do the low cohorts first
-    Rails.logger.info("Node: calling all role on_network_allocation_delete hooks for #{self}")
-    Role.all_cohorts.each do |r|
-      Rails.logger.info("Node: Calling #{r.name} on_network_allocation_delete for #{self}")
-      r.on_network_allocation_delete(self)
-    end
+    Event.fire(self, event: 'on_network_allocation_delete')
   end
 
   def on_create_hooks
@@ -71,11 +67,7 @@ class NetworkAllocation < ActiveRecord::Base
     # do the low cohorts first
     return if @after_create
     @after_create = true
-    Rails.logger.info("Node: calling all role on_network_allocation_create hooks for #{self}")
-    Role.all_cohorts.each do |r|
-      Rails.logger.info("Node: Calling #{r.name} on_network_allocation_create for #{self}")
-      r.on_network_allocation_create(self)
-    end
+    Event.fire(self, event: 'on_network_allocation_create')
   end
 
 end

--- a/rails/app/models/network_range.rb
+++ b/rails/app/models/network_range.rb
@@ -224,13 +224,10 @@ class NetworkRange < ActiveRecord::Base
     return if @after_create
     @after_create = true
     Rails.logger.info("NetworkRange: calling all role on_network_change hooks for #{network.name}")
-    Role.all_cohorts_desc.each do |r|
-      begin
-        Rails.logger.info("NetworkRange: Calling #{r.name} on_network_change for #{self.network.name}")
-        r.on_network_change(self.network)
-      rescue Exception => e
-        Rails.logger.error "NetworkRange #{self.name} attempting to change role #{r.name} failed with #{e.message}"
-      end
+    begin
+      Event.fire(self.network, event: 'on_network_change')
+    rescue Exception => e
+      Rails.logger.error "NetworkRange: on_network_change #{self.name} failed with #{e.message}"
     end
   end
 

--- a/rails/app/models/network_router.rb
+++ b/rails/app/models/network_router.rb
@@ -51,17 +51,12 @@ class NetworkRouter < ActiveRecord::Base
     # do the low cohorts last
     return if @after_create
     @after_create = true
-    Rails.logger.info("NetworkRouter: calling all role on_network_change hooks for #{network.name}")
-    Role.all_cohorts_desc.each do |r|
-      begin
-        Rails.logger.info("NetworkRouter: Calling #{r.name} on_network_change for #{self.network.name}")
-        r.on_network_change(self.network)
-      rescue Exception => e
-        Rails.logger.error "NetworkRouter #{self.address} attempting to change role #{r.name} failed with #{e.message}"
-      end
+    begin
+      Event.fire(self.network, event: 'on_network_change')
+    rescue Exception => e
+      Rails.logger.error "NetworkRouter: on_network_change #{self.address} failed with #{e.message}"
     end
   end
-
 
   def router_is_sane
     # A router is sane when its address is in a subnet covered by one of its ranges

--- a/rails/app/models/role.rb
+++ b/rails/app/models/role.rb
@@ -95,132 +95,55 @@ class Role < ActiveRecord::Base
   # before save is called if the state of the noderole has changed, so
   # roles that override these hooks MUST NOT do anything that calls
   # save on the noderole.
-  def sync_on_error(node_role, *args)
-    true
-  end
-
-  def sync_on_active(node_role, *args)
-    true
-  end
-
-  def sync_on_todo(node_role, *args)
-    true
-  end
-
-  def sync_on_transition(node_role, *args)
-    true
-  end
-
-  def sync_on_blocked(node_role, *args)
-    true
-  end
-
-  def sync_on_proposed(node_role, *args)
-    true
-  end
+  # sync_on_error
+  # sync_on_active(node_role, *args)
+  # sync_on_todo(node_role, *args)
+  # sync_on_transition(node_role, *args)
+  # sync_on_blocked(node_role, *args)
+  # sync_on_proposed(node_role, *args)
 
   # State Transistion Overrides
   # These are called after the relavent noderole has been saved to the
   # database, so they SHOULD NOT be used for anything that can fail.
-  def on_error(node_role, *args)
-    true
-  end
-
-  def on_active(node_role, *args)
-    true
-  end
-
-  def on_todo(node_role, *args)
-    true
-  end
-
-  def on_transition(node_role, *args)
-    true
-  end
-
-  def on_blocked(node_role, *args)
-    true
-  end
-
-  def on_proposed(node_role, *args)
-    true
-  end
-
-  # Event triggers for node creation and destruction.
-  # roles should override if they want to handle node addition
-  def on_node_create(node)
-    true
-  end
-
-  # Event triggers for node creation and destruction.
-  # roles should override if they want to handle node destruction
-  def on_node_delete(node)
-    true
-  end
-
-  # Event hook that will be called every time a node is saved if any attributes changed.
-  # Roles that are interested in watching nodes to see what has changed should
-  # implement this hook.
-  def on_node_change(node)
-    true
-  end
-
-  # Event hook that is called whenever a new deployment role is bound to a deployment.
-  # Roles that need do something on a per-deployment basis should override this
-  def on_deployment_create(dr)
-    true
-  end
-
-  # Event hook that is called whenever a deployment role is deleted from a deployment.
-  def on_deployment_delete(dr)
-    true
-  end
-
-  # Event triggers for node creation.
-  # roles should override if they want to handle network addition
-  def on_network_create(network)
-    true
-  end
-
-  # Event triggers for network destruction.
-  # roles should override if they want to handle network destruction
-  def on_network_delete(network)
-    true
-  end
-
-  # Event hook that will be called every time a network is saved if any attributes changed.
-  # Roles that are interested in watching networks to see what has changed should
-  # implement this hook.
-  #
-  # This does not include IP allocation/deallocation.
-  def on_network_change(network)
-    true
-  end
-
-  # Event hook that will be called every time a network allocation is created
-  def on_network_allocation_create(na)
-    true
-  end
-
-  # Event hook that will be called every time a network allocation is deleted
-  def on_network_allocation_delete(na)
-    true
-  end
+  # on_error(node_role, *args)
+  # on_active(node_role, *args)
+  # on_todo(node_role, *args)
+  # on_transition(node_role, *args)
+  # on_blocked(node_role, *args)
+  # on_proposed(node_role, *args)
+  # Event hook that is called after a noderole is created, but before it is
+  # committed.  This can be used to block the creation of a noderole by
+  # throwing an exception.
+  # on_node_bind(nr)
 
   # Event hook that is called whenever a noderole or a deployment role for this role is
   # committed.  It is called inline and synchronously with the actual commit, so it must be fast.
   # If it throws an exception, the commit will fail and the transaction around the commit
   # will be rolled back.
-  def on_commit(obj)
-    true
-  end
+  # on_commit(obj)
+  
+  # Event hook that is called whenever a new deployment role is bound to a deployment.
+  # Roles that need do something on a per-deployment basis should override this
+  # on_deployment_create(dr)
+  # on_deployment_delete(dr)
 
-  # Event hook that is called after a noderole is created, but before it is
-  # committed.  This can be used to block the creation of a noderole by
-  # throwing an exception.
-  def on_node_bind(nr)
-    true
-  end
+  # Event triggers for node creation and destruction.
+  # roles should override if they want to handle node addition
+  # on_node_create(node)
+  # on_node_delete(node)
+  # on_node_change(node)
+
+  # Event triggers for node creation.
+  # roles should override if they want to handle network addition
+  # on_network_create(network)
+  # on_network_delete(network)
+
+  # This does not include IP allocation/deallocation.
+  # on_network_change(network)
+
+  # Event hook that will be called every time a network allocation is created
+  # on_network_allocation_create(na)
+  # on_network_allocation_delete(na)
 
   def noop?
     jig.name.eql? 'noop'

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -204,6 +204,12 @@ Rebar::Application.routes.draw do
             put :recall
             get :graph
           end
+          resources :events do
+            collection do
+              get 'sample'
+              post 'match'
+            end
+          end
           resources :event_selectors do
             collection do
               get 'sample'

--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -204,6 +204,19 @@ Rebar::Application.routes.draw do
             put :recall
             get :graph
           end
+          resources :event_selectors do
+            collection do
+              get 'sample'
+              post 'match'
+            end
+          end
+          resources :event_sinks do
+            collection do
+              get 'sample'
+              post 'match'
+            end
+            resources :event_selectors
+          end
           resources :groups do
             resources :nodes
           end

--- a/rails/db/migrate/20160318135500_add_eventing.rb
+++ b/rails/db/migrate/20160318135500_add_eventing.rb
@@ -1,0 +1,51 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddEventing < ActiveRecord::Migration
+
+  def self.up
+    create_table :events do |t|
+      t.uuid        :uuid, nill: false, unique: true, default: 'gen_random_uuid()'
+      t.jsonb       :params, null: false
+      t.uuid        :event_selectors, array: true, default: []
+      t.text        :note
+      t.text        :target_class
+      t.jsonb       :target
+      t.timestamps
+    end
+
+    create_table :event_sinks do |t|
+      t.uuid   :uuid, null: false, unique: true, default: 'gen_random_uuid()'
+      t.text   :endpoint, null: false, unique: true
+      t.text   :username
+      t.text   :authenticator
+      t.text   :notes
+      t.timestamps
+    end
+
+    create_table :event_selectors do |t|
+      t.uuid   :uuid, null: false, unique: true, default: 'gen_random_uuid()'
+      t.belongs_to :event_sink, null: false
+      t.jsonb :selector, null: false
+      t.timestamps
+    end
+  end
+
+  def self.down
+    drop_table :event_sinks
+    drop_table :event_selectors
+    drop_table :events
+  end
+end


### PR DESCRIPTION
This moves role callbacks from being handled via method dispatch with
subclass-overridable methods to a centralized event dispatching system,
and updates the in-core classes to produce and consume the appropriate
events.

Implementation-wise, the code is set up to handle registering event
sinks that will recieve events, and event selectors that handle
selecting events that a given sink is interested in.  API endpoints for
event sinks and selectors have been created at the expected locations.

For now, the only event sink we know how to handle is the in-process
endpoint (named 'inproc://'), and all roles in the core that used the
method-based event handling scheme have been updated to register the
appropriate selectors at barclamp import time.

By adding an appropriate external endpoint handler and nailing down
exactly what we expect a sink to handle in terms of RPCs or pub/sub, we
can do away with forcing roles that need custom behaviour to live in the
same process space as the core.

This also paves the way for adding auditing events and other useful things.

This is still a work-in-progress -- the external barclamps would need to be updated to use this framework, and I am looking for comments and feedback.