### PR TITLE
All Network Range Delete from UI (Resolve Issue #1117)

### DIFF
--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1,7 +1,55 @@
 PATH
-  remote: /opt/digitalrebar/kubernetes/rebar_engine/barclamp_kubernetes
+  remote: /opt/digitalrebar/rackn/burnin/rebar_engine/barclamp_burnin
+  specs:
+    barclamp_burnin (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/ceph/rebar_engine/barclamp_ceph
+  specs:
+    barclamp_ceph (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/contrail/rebar_engine/barclamp_contrail
+  specs:
+    barclamp_contrail (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/enterprise/rebar_engine/barclamp_rack_n
+  specs:
+    barclamp_rack_n (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/hardware/bios/rebar_engine/barclamp_bios
+  specs:
+    barclamp_bios (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/hardware/ipmi/rebar_engine/barclamp_ipmi
+  specs:
+    barclamp_ipmi (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/hardware/raid/rebar_engine/barclamp_raid
+  specs:
+    barclamp_raid (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/kubernetes/rebar_engine/barclamp_kubernetes
   specs:
     barclamp_kubernetes (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/rackn/packstack/rebar_engine/barclamp_packstack
+  specs:
+    barclamp_packstack (0.0.1)
       rails
 
 GEM
@@ -469,7 +517,15 @@ PLATFORMS
 DEPENDENCIES
   active_scaffold
   audited-activerecord (~> 4.2.0)
+  barclamp_bios!
+  barclamp_burnin!
+  barclamp_ceph!
+  barclamp_contrail!
+  barclamp_ipmi!
   barclamp_kubernetes!
+  barclamp_packstack!
+  barclamp_rack_n!
+  barclamp_raid!
   berkshelf
   bunny
   chef (~> 12.3)

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1,55 +1,7 @@
 PATH
-  remote: /opt/digitalrebar/rackn/burnin/rebar_engine/barclamp_burnin
-  specs:
-    barclamp_burnin (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/ceph/rebar_engine/barclamp_ceph
-  specs:
-    barclamp_ceph (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/contrail/rebar_engine/barclamp_contrail
-  specs:
-    barclamp_contrail (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/enterprise/rebar_engine/barclamp_rack_n
-  specs:
-    barclamp_rack_n (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/hardware/bios/rebar_engine/barclamp_bios
-  specs:
-    barclamp_bios (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/hardware/ipmi/rebar_engine/barclamp_ipmi
-  specs:
-    barclamp_ipmi (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/hardware/raid/rebar_engine/barclamp_raid
-  specs:
-    barclamp_raid (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/kubernetes/rebar_engine/barclamp_kubernetes
+  remote: /opt/digitalrebar/kubernetes/rebar_engine/barclamp_kubernetes
   specs:
     barclamp_kubernetes (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/rackn/packstack/rebar_engine/barclamp_packstack
-  specs:
-    barclamp_packstack (0.0.1)
       rails
 
 GEM
@@ -517,15 +469,7 @@ PLATFORMS
 DEPENDENCIES
   active_scaffold
   audited-activerecord (~> 4.2.0)
-  barclamp_bios!
-  barclamp_burnin!
-  barclamp_ceph!
-  barclamp_contrail!
-  barclamp_ipmi!
   barclamp_kubernetes!
-  barclamp_packstack!
-  barclamp_rack_n!
-  barclamp_raid!
   berkshelf
   bunny
   chef (~> 12.3)

--- a/rails/app/controllers/network_ranges_controller.rb
+++ b/rails/app/controllers/network_ranges_controller.rb
@@ -106,4 +106,14 @@ class NetworkRangesController < ::ApplicationController
     render api_show @network_range
   end
 
+  # only works with ID, not name!
+  def destroy
+    @range = NetworkRange.find params[:id]
+    if params[:network_id]
+      raise "Range is not from the correct Network" unless @range.network_id = params[:network_id]
+    end
+    @range.destroy
+    render api_delete @range
+  end
+
 end

--- a/rails/app/controllers/networks_controller.rb
+++ b/rails/app/controllers/networks_controller.rb
@@ -83,7 +83,7 @@ class NetworksController < ::ApplicationController
     params.require(:group)
     params.require(:conduit)
     params.require(:deployment_id)
-    params.delete(:v6prefix) if params[:v6prefix] == ""
+    params.delete(:v6prefix) if params[:v6prefix] == "" or params[:v6prefix] == "none"
     params[:name] = "#{params[:category]}-#{params[:group]}"
     Network.transaction do
       @network = Network.create! params.permit(:name,

--- a/rails/app/views/network_ranges/_index.html.haml
+++ b/rails/app/views/network_ranges/_index.html.haml
@@ -14,7 +14,8 @@
           %td= text_field_tag :last, range.last, :size => 18
           %td
             %input.button{:type => "submit", :value => t('update')}
-
+            = link_to t('destroy'), "/api/v2/networks/#{network.id}/network_ranges/#{range.id}", :class => 'button', :'onclick'=>'location.reload();', :'data-remote' => true, :method => :delete, data: { confirm: "Are you certain you want to destroy range #{range.name}?" }
+            
     = form_for :network_range, :'data-remote' => true, :url => network_network_ranges_path(:network_id=>network.id, :api_version=>'v2'), :method=>:post, :html => { :method=>:post, :'data-type' => 'json',  :class => "formtastic", :remote=>true } do |f|
       %tr{ :class => cycle(:odd, :even) }
         %td

--- a/rails/app/views/networks/index.html.haml
+++ b/rails/app/views/networks/index.html.haml
@@ -3,10 +3,11 @@
 %table.data.box
   %thead
     %tr
-      %th= t '.name'
+      %th
+        = t '.category'
+        = "-"
+        = t '.group'
       %th= t '.description'
-      %th= t '.category'
-      %th= t '.group'
       %th= t '.deployment'
       %th= t '.vlan'
       %th= t '.v6prefix'
@@ -15,13 +16,12 @@
       %th= t '.conduit'
       %th= t '.pbr'
       %th= t '.ranges'
+      %th
   %tbody
     - @networks.each do |n|
       %tr.node{ :class => cycle(:odd, :even) }
-        %td= link_to n.name, network_path(n.id)
+        %td= link_to "#{n.category}-#{n.group}", network_path(n.id)
         %td= n.description
-        %td= n.category
-        %td= n.group
         %td= n.deployment.name
         %td= (n.use_vlan ? n.vlan : t('not_set') )
         %td= n.v6prefix
@@ -30,20 +30,26 @@
         %td= n.conduit
         %td= n.pbr
         %td= n.ranges.map{ |r| r.name }.join(', ')
+        %td= link_to t('destroy'), network_path(n.id), :class => 'button', :'onclick'=>'location.reload();', :'data-remote' => true, :method => :delete, data: { confirm: "Are you certain you want to destroy network #{n.name}?" }
+
   %tfoot
     = form_for :network, :'data-remote' => true, :url => networks_path(), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
       %tr
-        %td= t('.generated')
+        %td
+          = text_field_tag :category, 'general', :size=>7
+          = "-"
+          = text_field_tag :group, 'default', :size=>7
         %td= text_field_tag :description, "", :size=>20
-        %td= text_field_tag :category, 'general', :size=>10
-        %td= text_field_tag :group, 'default', :size=>10
         %td= select_tag :deployment_id, options_from_collection_for_select(Deployment.all, :id, :name)
         %td= text_field_tag :vlan, "-1", :size=>4
-        %td= text_field_tag :v6prefix, "auto", :size=>4
+        %td
+          = text_field_tag :v6prefix, "auto", :size=>4
+          = "[none]"
         %td= text_field_tag :bridge, "-1", :size=>4
         %td= text_field_tag :team_mode, "-1", :size=>4
         %td= text_field_tag :conduit, "10g1", :size=>4
         %td= text_field_tag :pbr, "", :size=>4
+        %td
         %td
           %input.button{:type => "submit", :value => t('.add')}
 


### PR DESCRIPTION
As per community discussion, there was no way to remove IPv6 ranges from the network if they were created by accident.

This change will allow users to delete ranges.

It also adds an explicit "none" for IPv6 ranges in addition to just leaving it blank.

Reference #1117
