### PR TITLE
fix use_team mode and conduit checks for issue #1120

### DIFF
--- a/rails/app/controllers/networks_controller.rb
+++ b/rails/app/controllers/networks_controller.rb
@@ -172,6 +172,10 @@ class NetworksController < ::ApplicationController
       # Sorry, but no changing of the admin conduit for now.
       params.delete(:conduit) if @network.name == "admin"
       params.delete(:v6prefix) if params[:v6prefix] == ""
+      # we need to reset the use_team flag if we only get a team mode
+      if params[:team_mode]
+        params[:use_team] = (params[:team_mode].to_i > 0) unless params[:use_team]
+      end
       if request.patch?
         patch(@network,%w{description vlan use_vlan v6prefix use_bridge team_mode use_team conduit configure pbr category group deployment_id})
       else

--- a/rails/app/models/network.rb
+++ b/rails/app/models/network.rb
@@ -321,7 +321,10 @@ class Network < ActiveRecord::Base
     # with conduits on other networks.  Ranges are not considered here.'
     Network.all.each do |net|
       unless Network.check_conduit_sanity(conduit, net.conduit)
-        errors.add(:conduit, "Network #{name}: Conduit mapping overlaps with network #{net.name}")
+        # unless this is the same network
+        unless name.eql? net.name
+          errors.add(:conduit, "Network #{name}: Conduit mapping overlaps with network #{net.name}")
+        end
       end
     end if conduit
 


### PR DESCRIPTION
From community, could not edit network to add team conduit.

Cause was that we were not resetting the use_team flag correctly AND logic was preventing updating the conduit maps on the same network.

Connect to #1120 