### PR TITLE
Add a UUID column to eveerything that is API accessible.

### DIFF
--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -11,12 +11,6 @@ PATH
       rails
 
 PATH
-  remote: /opt/digitalrebar/rackn/contrail/rebar_engine/barclamp_contrail
-  specs:
-    barclamp_contrail (0.0.1)
-      rails
-
-PATH
   remote: /opt/digitalrebar/rackn/enterprise/rebar_engine/barclamp_rack_n
   specs:
     barclamp_rack_n (0.0.1)
@@ -520,7 +514,6 @@ DEPENDENCIES
   barclamp_bios!
   barclamp_burnin!
   barclamp_ceph!
-  barclamp_contrail!
   barclamp_ipmi!
   barclamp_kubernetes!
   barclamp_packstack!

--- a/rails/db/migrate/20140430000001_drill_consolidated.rb
+++ b/rails/db/migrate/20140430000001_drill_consolidated.rb
@@ -28,7 +28,7 @@ class DrillConsolidated < ActiveRecord::Migration
     end
     add_index :settings, [ :target_type, :target_id, :var ], :unique => true
 
-    create_table(:navs, :primary_key=>'name', :id=>false) do |t|
+    create_table :navs, primary_key: 'name', id: false do |t|
       t.text      :item
       t.text      :parent_item,   default: 'root'
       t.text      :name
@@ -52,7 +52,7 @@ class DrillConsolidated < ActiveRecord::Migration
       t.timestamps
     end
 
-    create_table(:users) do |t|
+    create_table :users do |t|
       ## Database authenticatable
       t.text   :email,              null: false, default: "", index: true
       t.text   :encrypted_password, null: false, default: ""
@@ -299,7 +299,7 @@ class DrillConsolidated < ActiveRecord::Migration
     #natural key
     add_index(:node_groups, [:node_id, :group_id], unique: true)
 
-    create_table "networks" do |t|
+    create_table :networks do |t|
       t.references   :deployment, null: false
       t.text         :name,       null: false, index: { unique: true }
       t.text         :description,null: false, default: ''
@@ -322,14 +322,14 @@ class DrillConsolidated < ActiveRecord::Migration
     # required constraint
     add_index(:networks, [:category, :group], unique: true)
 
-    create_table "network_routers" do |t|
+    create_table :network_routers do |t|
       t.references   :network,    null: false
       t.text         :address,    null: false
       t.integer      :pref,       null: false, default: 65536
       t.timestamps
     end
 
-    create_table "network_ranges" do |t|
+    create_table :network_ranges do |t|
       t.text         :name,       null: false
       t.references   :network,    null: false
       # Both of these should also be CIDRs.
@@ -344,9 +344,9 @@ class DrillConsolidated < ActiveRecord::Migration
       t.boolean      :use_team,   null: true
       t.boolean      :overlap,    null: false, default: false   # 20150325101300
     end
-    add_index "network_ranges", [:network_id, :name], unique: true
+    add_index :network_ranges, [:network_id, :name], unique: true
 
-    create_table "network_allocations" do |t|
+    create_table :network_allocations do |t|
       t.references   :node
       t.references   :network,    null: false
       t.references   :network_range, null: false
@@ -355,7 +355,7 @@ class DrillConsolidated < ActiveRecord::Migration
     end
 
     # 20150613153000
-    create_table "dns_name_filters" do |t|
+    create_table :dns_name_filters do |t|
       t.text        :name,        null: false, default: 'default'
       t.text        :matcher,     null: false, default: 'net.category == "admin"'
       t.integer     :priority,    null: false, default: 50, index: { unique: true }
@@ -364,7 +364,7 @@ class DrillConsolidated < ActiveRecord::Migration
       t.timestamps
     end
 
-    create_table "dns_name_entries" do |t|
+    create_table :dns_name_entries do |t|
       t.belongs_to  :network_allocation,    null: false
       t.belongs_to  :dns_name_filter,       null: false
       t.text        :name,                  null: false, default: ''
@@ -430,7 +430,7 @@ class DrillConsolidated < ActiveRecord::Migration
     add_index :audits, [:user_id, :user_type], :name => 'user_index'
 
     # 20150619171000
-    create_table "audit_trackers" do |t|
+    create_table :audit_trackers do |t|
       t.text         :tracker,       index: { unique: true }
       t.integer      :processed,     default: 0
     end

--- a/rails/db/migrate/20160317102500_add_uuid_to_everything.rb
+++ b/rails/db/migrate/20160317102500_add_uuid_to_everything.rb
@@ -1,0 +1,62 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+require 'securerandom'
+
+class AddUuidToEverything < ActiveRecord::Migration
+
+  def change
+    # We need the pgcrypto extension enabled.
+    rtm={
+      attribs: Attrib,
+      available_hammers: AvailableHammer,
+      barclamps: Barclamp,
+      deployment_roles: DeploymentRole,
+      deployments: Deployment,
+      dns_name_entries: DnsNameEntry,
+      dns_name_filters: DnsNameFilter,
+      event_selectors: EventSelector,
+      event_sinks: EventSink,
+      groups: Group,
+      hammers: Hammer,
+      jigs: Jig,
+      network_allocations: NetworkAllocation,
+      network_ranges: NetworkRange,
+      network_routers: NetworkRouter,
+      networks: Network,
+      node_role_attrib_links: NodeRoleAttribLink,
+      node_roles: NodeRole,
+      nodes: Node,
+      password_change_tokens: PasswordChangeToken,
+      providers: Provider,
+      role_require_attribs: RoleRequireAttrib,
+      role_requires: RoleRequire,
+      roles: Role,
+      runs: Run,
+      users: User
+    }
+    rtm.each do |table, klass|
+      add_column table, :uuid, :uuid, default: 'gen_random_uuid()'
+      klass.all.each do |obj|
+        obj.uuid = SecureRandom.uuid if obj.uuid.nil?
+        obj.save!
+      end
+      change_column_null table, :uuid, false
+      add_index table, :uuid, unique: true
+    end
+  end
+  
+end
+

--- a/rails/lib/api_helper.rb
+++ b/rails/lib/api_helper.rb
@@ -26,11 +26,13 @@ module ApiHelper
 
   # for the top level classes (finders, etc)
   module ClassMethods
+    UUID_RE = /^[\h]{8}-[\h]{4}-[1-5][\h]{3}-[89abAB][\h]{3}-[\h]{12}$/
 
     # Helper to allow API to use ID or name
     def find_key(key)
       col,key = case
                 when db_id?(key) then [:id, key.to_i]
+                when UUID_RE.match(key) then [:uuid, key]
                 when key.is_a?(ActiveRecord::Base) then [:id, key.id]
                 when self.respond_to?(:name_column) then [name_column, key]
                 else [:name, key]


### PR DESCRIPTION
In order to accomidate renames of objects, we need a stable ID for
everything that does not reflect the internal Rails-assigned numeric
IDs.  V4 UUIDs are string-ish, globally unique, do not imply any
specific ordering, and are amenable to federation.