### PR TITLE
The run needs to store the wall into the node.

### DIFF
--- a/rails/app/models/run.rb
+++ b/rails/app/models/run.rb
@@ -82,9 +82,14 @@ class NodeRoleRun < Que::Job
       if (nr.wall["rebar_wall"]["reservations"] rescue nil)
         res = Hash.new
         nr.node.node_roles.each do |this_nr|
+          # We do ourselves last
+          next if nr.id == this_nr.id
+          # Use the local copy of this noderole instead of the stale one from the db.
           next unless (this_nr.wall["rebar_wall"]["reservations"] rescue nil)
           res.deep_merge!(this_nr.wall["rebar_wall"]["reservations"])
-          end
+        end
+        # Do this one last and not from a stale copy
+        res.deep_merge!(nr.wall["rebar_wall"]["reservations"])
         nr.node.hint_update({"reservations" => res})
       end
     rescue StandardError => e


### PR DESCRIPTION
The original code iterated through all node roles
and built a composite wall.  It looked them up from
the database.  The problem is that the current
node role under operation is update in memory
and not database yet.  The lookup gets stale
data and records the old data.  The new code
will move the current node role's data from
the current object at the end to make sure
it is accurate and most recent.