### PR TITLE
add network configuration override fields to provider

### DIFF
--- a/rails/app/models/open_stack_provider.rb
+++ b/rails/app/models/open_stack_provider.rb
@@ -23,7 +23,7 @@ class OpenStackProvider < CloudProvider
         type: "img",
         src: "https://www.openstack.org/assets/openstack-logo/R/openstack-cloud-software-vertical-web.png"
       },
-  	  :'os_auth_url' => {
+  	  :'os-auth-url' => {
         type: "text",
         default: "",
         length: 50,
@@ -58,6 +58,18 @@ class OpenStackProvider < CloudProvider
         default: "false",
         length: 8,
         name: I18n.t('os-debug', scope: "providers.show.openstack" )
+      },
+      :"os-network-external" => {
+        type: "text",
+        default: "auto",
+        length: 30,
+        name: I18n.t('os-network-external', scope: "providers.show.openstack" )
+      },
+      :"os-network-internal" => {
+        type: "text",
+        default: "auto",
+        length: 30,
+        name: I18n.t('os-network-internal', scope: "providers.show.openstack" )
       }
     }
   end

--- a/rails/app/views/providers/_openstackprovider.html.haml
+++ b/rails/app/views/providers/_openstackprovider.html.haml
@@ -1,25 +1,16 @@
+- template = OpenStackProvider.template
 %tr
   %td{:colspan=>2}
     %a{:href=>"http://openstack.org", :target=>"_blank"}
       = image_tag 'providers/openstack.png', :title=>"OpenStack", :width=>"138"
-%tr
-  %td= t 'os-auth-url', :scope=>'providers.show.openstack'  
-  %td= text_field_tag("auth_details[os-auth-url]", @item.auth_details['os-auth-url'], :size => 50)
-%tr
-  %td= t 'os-username', :scope=>'providers.show.openstack'
-  %td= text_field_tag("auth_details[os-username]", @item.auth_details['os-username'], :size => 30)
-%tr
-  %td= t 'os-password', :scope=>'providers.show.openstack'
-  %td= password_field_tag("auth_details[os-password]", @item.auth_details['os-password'], :size => 30)
-%tr
-  %td= t 'os-project-name', :scope=>'providers.show.openstack'	
-  %td= text_field_tag("auth_details[os-project-name]", @item.auth_details['os-project-name'], :size => 30)
-%tr
-  %td= t 'os-region-name', :scope=>'providers.show.openstack'	
-  %td= text_field_tag("auth_details[os-region-name]", @item.auth_details['os-region-name'], :size => 30)
-%tr
-  %td= t 'os-ssh-user', :scope=>'providers.show.openstack' 
-  %td= text_field_tag("auth_details[os-ssh-user]", @item.auth_details['os-ssh-user'] || "ubuntu centos", :size => 30)
-%tr
-  %td= t 'os-debug', :scope=>'providers.show.openstack'
-  %td= text_field_tag("auth_details[os-debug]", @item.auth_details['os-debug'] || "false", :size => 30)
+- template.each do |key, values|
+  -if values[:name]
+    %tr
+      %td= values[:name]
+      %td
+        - if values[:type] == "text"
+          = text_field_tag("auth_details[#{key}]", @item.auth_details[key.to_s] || values[:default], :size => values[:length])
+        - elsif values[:type] == "password"
+          = password_field_tag("auth_details[#{key}]", @item.auth_details[key.to_s], :size => values[:length])
+        - else
+          = "form for #{values[:type]} not implemented"

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -526,6 +526,8 @@ en:
         os-region-name: "Region Name"
         os-ssh-user: "SSH User(s)"
         os-debug: "Debug"
+        os-network-external: "[External Net Name|auto|none]"
+        os-network-internal: "[Internal Net Name|auto|none]"
   available_hammers:
     index:
       id: "ID"


### PR DESCRIPTION
my on-going saga to work on multiple openstack clouds means that there are some network mapping that just can't be figured out from inspected data alone.  Thus, I'm allowing users to force network names or say don't do any.  Default 'auto' will try and figure it out.

Also, made it so that the OpenStack UI page uses the template data.

This change should be made to other pages, but I'm keeping the change small for now.