### PR TITLE
Modifications to enable various features (SSO, Rev-Proxy, Cert System)

### DIFF
--- a/barclamps/dhcp.yml
+++ b/barclamps/dhcp.yml
@@ -82,9 +82,6 @@ roles:
                 name:
                   type: str
                   required: true
-                cert:
-                  type: str
-                  required: true
                 access_name:
                   type: str
                   required: true

--- a/barclamps/dns.yml
+++ b/barclamps/dns.yml
@@ -104,9 +104,6 @@ roles:
                 name:
                   type: str
                   required: true
-                cert:
-                  type: str
-                  required: true
                 access_name:
                   type: str
                   required: true

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -333,11 +333,13 @@ class ApplicationController < ActionController::Base
       session[:digest_user] = u.username
       u.encrypted_password
     end
+    Rails.logger.info("digest auth for #{u ? u.username : "unknown"}: #{authed}")
     @current_user = u if authed
     authed
   end
 
   def do_auth!
+    Rails.logger.info("Fail through auth: do_auth!")
     session[:marker] = "login"
     session[:start] = Time.now
     respond_to do |format|
@@ -348,6 +350,9 @@ class ApplicationController < ActionController::Base
 
   #return true if we digest signed in
   def rebar_auth
+    Rails.logger.debug("peercert: #{request.headers["puma.socket"].peercert}")
+    Rails.logger.info("username header: #{request.headers["HTTP_X_AUTHENTICATED_USERNAME"]}")
+    Rails.logger.info("capability header: #{request.headers["HTTP_X_AUTHENTICATED_CAPABILITY"]}")
     case
     when request.headers["puma.socket"].peercert && !request.headers["HTTP_X_AUTHENTICATED_USERNAME"].nil?
       username = request.headers["HTTP_X_AUTHENTICATED_USERNAME"]
@@ -369,7 +374,6 @@ class ApplicationController < ActionController::Base
 	@current_user.save
         @current_user = User.find_by(username: username)
       end
-      session[:digest_user] = username
       cors_headers
       true
     when current_user then authenticate_user!

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -355,6 +355,7 @@ class ApplicationController < ActionController::Base
     Rails.logger.info("capability header: #{request.headers["HTTP_X_AUTHENTICATED_CAPABILITY"]}")
     case
     when request.headers["puma.socket"].peercert && !request.headers["HTTP_X_AUTHENTICATED_USERNAME"].nil?
+      # This assumes that the rev-proxy is handling cors
       username = request.headers["HTTP_X_AUTHENTICATED_USERNAME"]
       capability = request.headers["HTTP_X_AUTHENTICATED_CAPABILITY"]
       wants_admin = capability == "ADMIN"
@@ -374,7 +375,7 @@ class ApplicationController < ActionController::Base
 	@current_user.save
         @current_user = User.find_by(username: username)
       end
-      cors_headers
+      session[:digest_user] = username
       true
     when current_user then authenticate_user!
     when digest_request? then digest_auth!

--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -349,6 +349,12 @@ class ApplicationController < ActionController::Base
   #return true if we digest signed in
   def rebar_auth
     case
+    when request.headers["puma.socket"].peercert && !request.headers["HTTP_X_AUTHENTICATED_USERNAME"].nil?
+      username = request.headers["HTTP_X_AUTHENTICATED_USERNAME"]
+      session[:digest_user] = username
+      Rails.logger.info("Auth by key: #{username}")
+      @current_user = User.find_by(username: "rebar")
+      true
     when current_user then authenticate_user!
     when digest_request? then digest_auth!
     when request.path == '/api/license' then true  # specialized path for license & URL validation
@@ -362,4 +368,5 @@ class ApplicationController < ActionController::Base
       do_auth!
     end
   end
+
 end

--- a/rails/app/controllers/support_controller.rb
+++ b/rails/app/controllers/support_controller.rb
@@ -216,11 +216,4 @@ class SupportController < ApplicationController
     end
   end
   
-  def do_auth!
-    case
-    when request.fullpath.index("/get_cli") || request.fullpath.index("/logs") then digest_auth!
-    else
-      super
-    end
-  end
 end 

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -22,11 +22,8 @@ class UsersController < ApplicationController
 
   add_help(:index,[],[:get])
 
-#  skip_before_filter :rebar_auth, :only => [:options, :digest]
-#  skip_before_filter :authenticate_user!, :only => [:options]
-#  before_filter :digest_auth!, :only => [:digest]
-
   skip_before_filter :rebar_auth, :only => [:options]
+  skip_before_filter :authenticate_user!, :only => [:options]
 
   def cors_headers
     access_control = {

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -22,9 +22,11 @@ class UsersController < ApplicationController
 
   add_help(:index,[],[:get])
 
-  skip_before_filter :rebar_auth, :only => [:options, :digest]
-  skip_before_filter :authenticate_user!, :only => [:options]
-  before_filter :digest_auth!, :only => [:digest]
+#  skip_before_filter :rebar_auth, :only => [:options, :digest]
+#  skip_before_filter :authenticate_user!, :only => [:options]
+#  before_filter :digest_auth!, :only => [:digest]
+
+  skip_before_filter :rebar_auth, :only => [:options]
 
   def cors_headers
     access_control = {

--- a/rails/app/controllers/users_controller.rb
+++ b/rails/app/controllers/users_controller.rb
@@ -38,7 +38,6 @@ class UsersController < ApplicationController
   def digest
     if request.get? or request.post? or request.head?
       if request.headers["HTTP_ORIGIN"]
-        cors_headers
         user = User.find_key session[:digest_user]
         if user
           render api_show(user), :status => :accepted
@@ -58,7 +57,7 @@ class UsersController < ApplicationController
     end
   end
 
-  # CORS header method
+  # CORS header method - not used for rev_proxy
   def options
     cors_headers
     response.headers['Access-Control-Allow-Methods'] = 'GET,POST,PUT,DELETE,OPTIONS,PATCH,HEAD'

--- a/rails/app/models/barclamp_dhcp/mgmt_service.rb
+++ b/rails/app/models/barclamp_dhcp/mgmt_service.rb
@@ -230,37 +230,37 @@ class BarclampDhcp::MgmtService < Service
     end
   end
 
-  def self.send_request_put(url, data, ca_string)
+  def self.get_base_resource(url)
     store = OpenSSL::X509::Store.new
-    store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
+    store.add_cert(OpenSSL::X509::Certificate.new(File.read('/var/run/rebar/ca.pem')))
+
+    # get client key and cert
+    client_cert = OpenSSL::X509::Certificate.new(File.read('/var/run/rebar/server.crt'))
+    client_key  = OpenSSL::PKey::RSA.new(File.read('/var/run/rebar/server.key'), '')
 
     RestClient::Resource.new(
         url,
-        :ssl_cert_store =>  store,
-        :verify_ssl     =>  OpenSSL::SSL::VERIFY_PEER
-    ).put data.to_json, :content_type => :json, :accept => :json
+        :ssl_cert_store  =>  store,
+	:ssl_client_cert =>  client_cert,
+	:ssl_client_key  =>  client_key,
+        :verify_ssl      =>  OpenSSL::SSL::VERIFY_PEER
+    )
   end
 
-  def self.send_request_post(url, data, ca_string)
-    store = OpenSSL::X509::Store.new
-    store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
-
-    RestClient::Resource.new(
-        url,
-        :ssl_cert_store =>  store,
-        :verify_ssl     =>  OpenSSL::SSL::VERIFY_PEER
-    ).post data.to_json, :content_type => :json, :accept => :json
+  def self.send_request_get(url)
+    get_base_resource(url).get
   end
 
-  def self.send_request_delete(url, ca_string)
-    store = OpenSSL::X509::Store.new
-    store.add_cert(OpenSSL::X509::Certificate.new(ca_string))
+  def self.send_request_put(url, data)
+    get_base_resource(url).put data.to_json, :content_type => :json, :accept => :json
+  end
 
-    RestClient::Resource.new(
-        url,
-        :ssl_cert_store =>  store,
-        :verify_ssl     =>  OpenSSL::SSL::VERIFY_PEER
-    ).delete
+  def self.send_request_post(url, data)
+    get_base_resource(url).post data.to_json, :content_type => :json, :accept => :json
+  end
+
+  def self.send_request_delete(url)
+    get_base_resource(url).delete
   end
 
   #
@@ -287,7 +287,7 @@ class BarclampDhcp::MgmtService < Service
 
     url = "#{service['url']}/subnets"
 
-    send_request_post(url, hash, service['cert'])
+    send_request_post(url, hash)
   end
 
   def self.update_network(name, subnet, next_server, start_ip, end_ip, options)
@@ -308,14 +308,14 @@ class BarclampDhcp::MgmtService < Service
 
     url = "#{service['url']}/subnets/#{name}"
 
-    send_request_put(url, hash, service['cert'])
+    send_request_put(url, hash)
   end
 
   def self.delete_network(name)
     service = get_service
     return unless service
     url = "#{service['url']}/subnets/#{name}"
-    send_request_delete(url, service['cert'])
+    send_request_delete(url)
   end
 
   def self.bind_node_ip_mac(name, mac, ip, bootenv, loader)
@@ -346,14 +346,14 @@ class BarclampDhcp::MgmtService < Service
     service = get_service
     return unless service
     url = "#{service['url']}/subnets/#{name}/bind"
-    send_request_post(url, hash, service['cert'])
+    send_request_post(url, hash)
   end
 
   def self.unbind_node_ip_mac(name, mac)
     service = get_service
     return unless service
     url = "#{service['url']}/subnets/#{name}/unbind/#{mac}"
-    send_request_post(url, hash, service['cert'])
+    send_request_post(url, hash)
   end
 
 end

--- a/rails/puma.cfg
+++ b/rails/puma.cfg
@@ -1,4 +1,4 @@
-bind("ssl://[::]:3000?key=/var/run/rebar/server.key&cert=/var/run/rebar/server.crt")
+bind("ssl://[::]:3000?key=/var/run/rebar/server.key&cert=/var/run/rebar/server.crt&ca=/var/run/rebar/ca.pem&verify_mode=peer")
 pidfile("/var/run/rebar/rebar.pid")
 rackup("config.ru")
 environment("production")

--- a/tools/da-lib.sh
+++ b/tools/da-lib.sh
@@ -50,7 +50,7 @@ converge() {
     return 1
 }
 
-known_containers=(provisioner dhcp ntp dns dns-mgmt revproxy chef webproxy logging debug node access ux)
+known_containers=(provisioner dhcp ntp dns dns-mgmt revproxy trust-me chef webproxy logging debug node access ux)
 
 declare -A containers
 

--- a/tools/da-lib.sh
+++ b/tools/da-lib.sh
@@ -50,7 +50,7 @@ converge() {
     return 1
 }
 
-known_containers=(provisioner dhcp ntp dns dns-mgmt revproxy trust-me chef webproxy logging debug node access ux)
+known_containers=(provisioner dhcp ntp dns dns-mgmt revproxy chef webproxy logging debug node access ux)
 
 declare -A containers
 


### PR DESCRIPTION
This is to support the work in the deploy pull request: #999 

This code turns on client-side certificate validation and makes the results available to the rails app.  The
rails app will use this validation to by-pass normal auth.  This allows the rev-proxy to access the API and UI without requiring password passing or auth access.  This enables SSO and external auth.  The users are dynamically created to allow the rest of the system to handle user tracking.

This also updates the service mgmt classes to use client-based certificate authentication instead of hard-coded passwords to manipulate the DHCP, DNS, and provisioner services.

Also introduces the initial ability to define capability based access control.