### PR TITLE
add ! prefix to omit default values in providers...

### DIFF
--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -120,6 +120,8 @@ class ProvidersController < ApplicationController
     params[:auth_details].each do |key, value|
       if (value.is_a? String) and (key =~ /json/ or value.start_with?("{"))
         out[key] = JSON.parse(value) 
+      elsif value.start_with? "!"
+        # noop, we are going to drop values that start with !
       else
         out[key] = value
       end

--- a/rails/app/models/aws_provider.rb
+++ b/rails/app/models/aws_provider.rb
@@ -50,7 +50,13 @@ class AwsProvider < CloudProvider
     		default: "us-west-2",
     		length: 30,
     		name: I18n.t('region', scope: "providers.show.aws" )
-  		}
+  		},
+      vpc_id: {
+        type: "text",
+        default: "!default",
+        length: 30,
+        name: I18n.t('vpc_id', scope: "providers.show.aws" )
+      }
     }
   end
 

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -510,6 +510,7 @@ en:
         access_key_id: "Access Key"
         secret_access_key: "Secret"
         region: "Region"
+        vpc_id: "VPC ID"
       packet:
         token: "Token"
         id: "ID"


### PR DESCRIPTION
from being passed into configuration as needed for AWS VPC_ID (which is included in patch).

Basically, this allows us to create UI that has truly optional inputs w/o additional logic.  If the ! is included as a prefix in UI fields, then the parser will not include them in the auth_details JSON file.

For API driven actions, this path is NOT used.  It is only engaged by the Web UI passing form details.

To support work AWS integration @lachie83