### PR TITLE
Add role preceeds list.

### DIFF
--- a/barclamps/provisioner.yml
+++ b/barclamps/provisioner.yml
@@ -209,7 +209,7 @@ roles:
             obj_class: role
             obj_id: provisioner-os-install
     requires:
-      - rebar-hardware-configured
+      - rebar-managed-node
     flags:
       - implicit
       - destructive

--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -47,6 +47,8 @@ roles:
       - implicit
       - milestone
       - powersave
+    preceeds:
+      - provisioner-os-install
     requires:
       - rebar-managed-node
   - name: rebar-installed-node
@@ -58,7 +60,6 @@ roles:
       - implicit
       - powersave
     requires:
-      - rebar-hardware-configured
       - provisioner-os-install
   - name: rebar-docker-node
     description: "Docker Node Ready Checkpoint"

--- a/rails/app/models/role_preceed.rb
+++ b/rails/app/models/role_preceed.rb
@@ -1,0 +1,77 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class RolePreceed < ActiveRecord::Base
+
+  belongs_to      :role
+  belongs_to      :child, class_name: Role, foreign_key: "child_role_id"
+
+  validate :enforce_acyclic, on: :create
+
+  after_create :resolve_preceeds
+
+  def resolved?
+    !child_role_id.nil?
+  end
+
+  def resolve!
+    return if resolved?
+    Rails.logger.info("RolePreceed: Trying to resolve #{preceeds} to a Role for #{role.name}")
+    r = Role.find_by(name: self.preceeds)
+    return unless r
+    Rails.logger.info("RolePreceed: #{preceeds} resolves to role ID #{r.id}")
+    update_column(:child_role_id, r.id)
+    child.update_cohort
+  end
+
+
+  private
+
+  # If there is a path in the graph from requires back to role_id,
+  # then allowing this RoleRequire to be created would make the role graph
+  # cyclic, and that is Not Allowed.
+  def enforce_acyclic
+    us = role_id
+    them = Role.find_by(name: preceeds)
+    # If our source role has not been added yet, then there is no way we can
+    # tell if adding this RoleRequires will result in a cyclic graph.
+    # However, in that case the cycle will be detected when the role that
+    # requires refers to adds its own RoleRequires, so we don't have to worry
+    # about it here in any case.
+    return true if them.nil?
+    # Find all the roles that target_role depends on that depend on
+    # source_role. If there are none, then adding this role cannot create
+    # a dependency loop, and we are OK.
+    return true if Role.where("id in (
+                                  select role_id from all_role_requires
+                                  where role_id = ? AND required_role_name = ?)",
+                              us,
+                              them.name).empty?
+    # Well, that is that. We will die, but we will be precise about why we die.
+    errors[:base] << "RolePreceed: #{role.name} preceeding #{them.name} makes the role graph cyclic!"
+    paths = Role.connection.select_all("select path from all_role_requires_paths where child_name = '#{them.name}' AND parent_name = '#{role.name}'")
+    unless paths.empty?
+      errors[:base] << "Role dependency chains that would be made cyclic:"
+      paths.rows.each do |path|
+        errors[:base] << "  #{path[0][1..-2].split(",").join(" -> ")}  (-> #{preceeds})"
+      end
+    end
+  end
+
+  def resolve_preceeds
+    resolve!
+  end
+
+end

--- a/rails/app/views/roles/_index.html.haml
+++ b/rails/app/views/roles/_index.html.haml
@@ -10,6 +10,7 @@
         %th= t '.description'
         %th= t '.flags'
         %th= t '.upstream'
+        %th= t '.preceeds'
         %th= t '.provides'
         %th= t '.conflicts'
     %tbody
@@ -31,6 +32,9 @@
           %td
             - role.parents.each do |p|
               = link_to p.name, role_path(p), :title=>p.description
+          %td
+            - role.preceeds.each do |r|
+              = link_to r, role_path(r)
           %td
             - role.provides.each do |r|
               = link_to r, role_path(r)

--- a/rails/config/locales/rebar/en.yml
+++ b/rails/config/locales/rebar/en.yml
@@ -574,6 +574,7 @@ en:
       destructive: "Destructive"
       service: "Service"
       provides: "Provides"
+      preceeds: "Preceeds"
       conflicts: "Conflicts"
       server: "Server"
       description: "Description"

--- a/rails/db/migrate/20160602094000_add_role_preceeds.rb
+++ b/rails/db/migrate/20160602094000_add_role_preceeds.rb
@@ -1,0 +1,29 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class AddRolePreceeds < ActiveRecord::Migration
+
+  def change
+    add_column :roles, :preceeds, :text, array: true, null: false, default: { expr: "ARRAY[]::text[]" }
+    create_table :role_preceeds do |t|
+      t.belongs_to :role, null: false
+      t.text :preceeds, null: false, index: true
+      t.integer :child_role_id, foreign_key: { references: :roles, name: "role_preceeds_fk" }
+    end
+    add_index(:role_preceeds, [:role_id, :preceeds], unique: true)
+    
+  end
+  
+end


### PR DESCRIPTION
Preceeds indicates that when the role is bound to a node, it should
preceed (run before) roles in the preceeds list.  If the role it
preceeds has the implicit flag, then it will only preceed the noderole
that is bound to the node, otherwise it will preceed a randomly-chosen
noderole for the node it preceeds.