### PR TITLE
Fix deployment commit and destroy bugs.

### DIFF
--- a/rails/app/models/deployment.rb
+++ b/rails/app/models/deployment.rb
@@ -128,12 +128,14 @@ class Deployment < ActiveRecord::Base
 
   def commit
     Deployment.transaction do
-      deployment_roles.all.each{|dr|dr.commit if dr.proposed?}
-      node_roles.in_state(NodeRole::PROPOSED).each { |nr| nr.commit! }
       if proposed?
         write_attribute("state",COMMITTED)
         save!
       end
+    end
+    Deployment.transaction do
+      deployment_roles.all.each{|dr|dr.commit if dr.proposed?}
+      node_roles.in_state(NodeRole::PROPOSED).each { |nr| nr.commit! }
     end
     Run.run!
     self


### PR DESCRIPTION
Deployment commit was needlessly slow due to IPMI controller actions
happening in the same transaction as the deployment and noderole
commits.  Resolved that by moving node auto power on logic into the
noderole after_commit hook.

Deleting a noderole would wipe out all the edges in the noderole graph
instead of just the local edges.  This ahppened because delete_sql was
no longer honored on habtm relations.  Refactored the noderole model to
have all_parents and all_children be a function which returns the
appropriate relation instead of the relation itself.