### PR TITLE
Improve locking around runs to increase parallelism.

### DIFF
--- a/rails/db/migrate/20160616160500_create_partial_unique_index_for_running_runs.rb
+++ b/rails/db/migrate/20160616160500_create_partial_unique_index_for_running_runs.rb
@@ -1,0 +1,22 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class CreatePartialUniqueIndexForRunningRuns < ActiveRecord::Migration
+
+  def up
+    execute 'CREATE UNIQUE INDEX index_running_runs ON runs (node_id) WHERE running;'
+  end
+
+end


### PR DESCRIPTION
Locking around the runs table was being a little too paranoid, resulting
in the runners being starved to work due to the overhead in acquiring
the right locks.  This commit adds a partial index to guarantee that we
can only ever have one run per node in the database, relaxes some
locking that was previously enforcing that invariant, and takes
advantage of new FOR UPDATE SKIP LOCKED in Postgres 9.5 that is designed
to help highly contended queue-like tables perform better.