### PR TITLE
Ignore failure to delete nonexistent networks from the DHCP server.

### DIFF
--- a/rails/app/models/barclamp_dhcp/mgmt_service.rb
+++ b/rails/app/models/barclamp_dhcp/mgmt_service.rb
@@ -81,7 +81,11 @@ class BarclampDhcp::MgmtService < Service
     r = network.ranges.find_by(name: "host") unless r
     unless r
       # All goes away, makes sure we pull it.
-      self.class.delete_network(network.name)
+      begin
+        self.class.delete_network(network.name)
+      rescue RestClient::ResourceNotFound
+        return
+      end
       return
     end
 


### PR DESCRIPTION
It is perfectly cromulent to fail to delete subnets from the DHCP
server that do not exist.  THis can happen when creating networks
without ranges, as happens in the UI.