### PR TITLE
Add general purpose Service Role

### DIFF
--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1,3 +1,27 @@
+PATH
+  remote: /opt/digitalrebar/hardware/bios/rebar_engine/barclamp_bios
+  specs:
+    barclamp_bios (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/hardware/ipmi/rebar_engine/barclamp_ipmi
+  specs:
+    barclamp_ipmi (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/hardware/raid/rebar_engine/barclamp_raid
+  specs:
+    barclamp_raid (0.0.1)
+      rails
+
+PATH
+  remote: /opt/digitalrebar/kubernetes/rebar_engine/barclamp_kubernetes
+  specs:
+    barclamp_kubernetes (0.0.1)
+      rails
+
 GEM
   remote: https://rubygems.org/
   specs:
@@ -455,6 +479,10 @@ PLATFORMS
 
 DEPENDENCIES
   active_scaffold
+  barclamp_bios!
+  barclamp_ipmi!
+  barclamp_kubernetes!
+  barclamp_raid!
   berkshelf
   bunny
   chef (~> 12.3)
@@ -497,4 +525,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.12.5
+   1.11.2

--- a/rails/Gemfile.lock
+++ b/rails/Gemfile.lock
@@ -1,27 +1,3 @@
-PATH
-  remote: /opt/digitalrebar/hardware/bios/rebar_engine/barclamp_bios
-  specs:
-    barclamp_bios (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/hardware/ipmi/rebar_engine/barclamp_ipmi
-  specs:
-    barclamp_ipmi (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/hardware/raid/rebar_engine/barclamp_raid
-  specs:
-    barclamp_raid (0.0.1)
-      rails
-
-PATH
-  remote: /opt/digitalrebar/kubernetes/rebar_engine/barclamp_kubernetes
-  specs:
-    barclamp_kubernetes (0.0.1)
-      rails
-
 GEM
   remote: https://rubygems.org/
   specs:
@@ -479,10 +455,6 @@ PLATFORMS
 
 DEPENDENCIES
   active_scaffold
-  barclamp_bios!
-  barclamp_ipmi!
-  barclamp_kubernetes!
-  barclamp_raid!
   berkshelf
   bunny
   chef (~> 12.3)
@@ -525,4 +497,4 @@ DEPENDENCIES
   xml-simple
 
 BUNDLED WITH
-   1.11.2
+   1.12.5

--- a/rails/app/models/barclamp_rebar/service_role.rb
+++ b/rails/app/models/barclamp_rebar/service_role.rb
@@ -1,0 +1,50 @@
+# Copyright 2016, RackN
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+class BarclampRebar::ServiceRole < Role
+
+  def sync_on_destroy(nr, *args)
+    collect_addresses(nr, args)
+  end
+
+  def on_active(nr, *args)
+    collect_addresses(nr, args)
+  end
+
+  private
+
+  def collect_addresses(nr, *args)
+
+    aname = "#{nr.role.name}-addresses"
+    addresses = []
+
+    d = nr.deployment
+    d.node_roles.where(role_id: nr.role_id).each do |nrs|
+      if nrs.active?
+        n = nrs.node
+        str_addr = n.get_attrib('node-control-address')
+        str_addr ||= n.addresses.first.addr.to_s 
+        addresses << str_addr
+      end
+    end
+
+    Rails.logger.info("Updating #{nr.role.name} #{aname}: #{addresses.inspect}")
+    Attrib.set(aname,nr.deployment_role,addresses)
+
+    true
+
+  end
+
+end

--- a/rails/app/models/node_role.rb
+++ b/rails/app/models/node_role.rb
@@ -484,7 +484,7 @@ class NodeRole < ActiveRecord::Base
     res.deep_merge(all_my_data)
   end
 
- # Gather all of the attribute data needed for a single noderole run.
+  # Gather all of the attribute data needed for a single noderole run.
   # It should be run to create whatever information will be needed
   # for the actual run before doing the actual run in a delayed job.
   # RETURNS the attribute data needed for a single noderole run.
@@ -712,6 +712,8 @@ class NodeRole < ActiveRecord::Base
       all_children.order("cohort DESC").each do |c|
         c.destroy
       end
+      # if we can destroy, then we also need to run the sync_on_delete method
+      Event.fire(self, obj_class: "role", obj_id: role.name, event: "sync_on_destroy")
       return true
     end
   end

--- a/rails/app/models/role.rb
+++ b/rails/app/models/role.rb
@@ -129,6 +129,7 @@ class Role < ActiveRecord::Base
   # sync_on_transition(node_role, *args)
   # sync_on_blocked(node_role, *args)
   # sync_on_proposed(node_role, *args)
+  # sync_on_destroy(node_role, *args)
 
   # State Transistion Overrides
   # These are called after the relavent noderole has been saved to the

--- a/rails/app/views/roles/show.html.haml
+++ b/rails/app/views/roles/show.html.haml
@@ -9,9 +9,8 @@
     %dd= link_to @role.jig_name, jig_path(@role.jig_name)
     %dt= t '.barclamp' 
     %dd= link_to @role.barclamp.name, barclamp_path(@role.barclamp.id), :title=>@role.barclamp.description
-    - if Rails.env.development?
-      %dt= t '.type'
-      %dd= "[#{@role.class.to_s}]"
+    %dt= t '.type'
+    %dd= "[#{@role.class.to_s}]"
     - if @role.github and (current_user.settings(:docs).sources rescue false)
       %dt= t '.source'
       %dd= link_to @role.github, @role.github


### PR DESCRIPTION
This role can be used by any role that needs to collect service IPs as an attribute.  Very handy for multi-node services (like etdc or kubernetes api or consul-master)

At some point, we could retrofit consul.

REQUIRES that you add an attrib & event declaration in the role.