### PR TITLE
Allow for UTC to be removed by collection Delete with parameters

### DIFF
--- a/rails/config/routes.rb
+++ b/rails/config/routes.rb
@@ -164,6 +164,7 @@ Rebar::Application.routes.draw do
           end
           resources :user_tenant_capabilities do
             collection do
+              delete "", to: :destroy
               get 'sample'
               post 'match'
             end


### PR DESCRIPTION
This enables the collection DELETE on UTCs so that they can be deleted with an id.