### PR TITLE
Update Node Role Permissions to use Deployment Caps

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -491,6 +491,7 @@ class ApplicationController < ActionController::Base
       if validate_capability(t_id, "#{cap_base}_READ")
         raise RebarForbiddenError.new(key, klass)
       else
+        Rails.logger.warn("Tenant {t_id}: #{cap_base}_#{action} NOT DEFINED for #{klass} id #{key}")
         raise RebarNotFoundError.new(key, klass)
       end
     end
@@ -502,6 +503,7 @@ class ApplicationController < ActionController::Base
 
   def validate_read(t_id, cap_base, klass, key)
     unless validate_capability(t_id, "#{cap_base}_READ")
+      Rails.logger.warn("Tenant {t_id}: #{cap_base}_READ NOT DEFINED for #{klass} id #{key}")
       raise RebarNotFoundError.new(key, klass)
     end
   end

--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -204,7 +204,7 @@ class NodeRolesController < ApplicationController
 
   def destroy
     @node_role = NodeRole.find_key (params[:id] || params[:node_role_id])
-    validate_destroy(@node_role.tenant_id, "NODE", NodeRole, @node_role.id)
+    validate_destroy(@node_role.tenant_id, "DEPLOYMENT", NodeRole, @node_role.id)
     @node_role.destroy
     respond_to do |format|
       format.html { redirect_to deployment_path(@node_role.deployment_id) }
@@ -214,7 +214,7 @@ class NodeRolesController < ApplicationController
 
   def propose
     @node_role = NodeRole.find_key params[:node_role_id]
-    validate_action(@node_role.tenant_id, "NODE", NodeRole, @node_role.id, "PROPOSE")
+    validate_action(@node_role.tenant_id, "DEPLOYMENT", NodeRole, @node_role.id, "PROPOSE")
     @node_role.propose!
     respond_to do |format|
       format.html { redirect_to node_role_path(@node_role.id) }
@@ -224,7 +224,7 @@ class NodeRolesController < ApplicationController
 
   def commit
     @node_role = NodeRole.find_key params[:node_role_id]
-    validate_action(@node_role.tenant_id, "NODE", NodeRole, @node_role.id, "COMMIT")
+    validate_action(@node_role.tenant_id, "DEPLOYMENT", NodeRole, @node_role.id, "COMMIT")
     @node_role.commit!
     respond_to do |format|
       format.html { redirect_to node_role_path(@node_role.id) }
@@ -235,12 +235,9 @@ class NodeRolesController < ApplicationController
   def retry
     params[:id] ||= params[:node_role_id]
     @node_role = NodeRole.find_key params[:id]
-    validate_action(@node_role.tenant_id, "NODE", NodeRole, @node_role.id, "RETRY")
+    validate_action(@node_role.tenant_id, "DEPLOYMENT", NodeRole, @node_role.id, "RETRY")
     @node_role.todo!
-    respond_to do |format|
-      format.html { redirect_to node_role_path(@node_role.id) }
-      format.json { render api_show @node_role }
-    end
+    render api_show @node_role
   end
 
   def parents

--- a/rails/app/views/node_roles/_index.html.haml
+++ b/rails/app/views/node_roles/_index.html.haml
@@ -42,5 +42,5 @@
             .led{:class => nr_led, :title=>nr.state_name}
           %td= link_to nr.state_name, node_role_path(nr.id)
           - if nr.state == NodeRole::ERROR
-            %td= link_to t('.retry'), "/api/v2"+node_role_path(nr.id)+"/retry", :class => 'button', :method=>:put, :'data-remote' => true
+            %td= link_to t('.retry'), "/api/v2/node_roles/#{nr.id}/retry", :class => 'button', :method=>:put, :'data-remote' => true
 

--- a/rails/app/views/node_roles/show.html.haml
+++ b/rails/app/views/node_roles/show.html.haml
@@ -11,7 +11,7 @@
       = @node_role.state_name
     - if @node_role.error? || @node_role.active?
       %td{:width=>'100%', :align=>'right'}
-        = link_to t('.retry'), "/api/v2"+node_role_path(@node_role.id)+"/retry.html", :class => 'button', :method=>:put
+        = link_to t('.retry'), "/api/v2/node_roles/#{@node_role.id}/retry", :class => 'button', :method=>:put, :'data-remote' => true
 
 - if @node_role.state == NodeRole::ERROR
   - has_hint = t(@node_role.role.name, :scope => 'node_roles.show.error_hints', :default => 'none')

--- a/rails/config/navigation.rb
+++ b/rails/config/navigation.rb
@@ -16,7 +16,7 @@ SimpleNavigation::Configuration.run do |navigation|
   menu = Nav.item('root').first
   navigation.items do |primary|
     # add link to new ux
-    primary.item :ux, t('nav.ux'), 'ux/', :html => {:title=>t('nav.ux_description')}, :link_html => {:target=>"_drux"}
+    primary.item :ux, t('nav.ux'), '/ux/', :html => {:title=>t('nav.ux_description')}, :link_html => {:target=>"_drux"}
     # database driven menu
     menu.children.sort_by{|n| n.order}.each do |item| # Top Nav
       if item.item != 'root' and item.path =~ /(.*)_path/


### PR DESCRIPTION
The Caps needed for these actions are from the deployment, not the node.

I added some logging to make this easier to find in the future (you should not need debug logging to find missing caps)

Also, retry does not need to return HTML, JSON only.  The other actions could likely use the same refactoring.

Change for _index is looks bigger because it had wrong line endings. 