### PR TITLE
Overhaul controllers to push cap checking into the database.

### DIFF
--- a/rails/app/controllers/available_hammers_controller.rb
+++ b/rails/app/controllers/available_hammers_controller.rb
@@ -19,15 +19,15 @@ class AvailableHammersController < ApplicationController
 
   # API GET /api/v2/available_hammers
   def index
-    @hammers = AvailableHammer.order('priority')
+    @hammers = model.order('priority')
     respond_to do |format|
       format.html { } # show.html.erb
-      format.json { render api_index AvailableHammer, @hammers }
+      format.json { render api_index model, @hammers }
     end
   end
 
   def show
-    @hammer = AvailableHammer.find_key params[:id]
+    @hammer = model.find_key params[:id]
     respond_to do |format|
       format.html {  }
       format.json { render api_show @hammer }

--- a/rails/app/controllers/barclamps_controller.rb
+++ b/rails/app/controllers/barclamps_controller.rb
@@ -18,19 +18,15 @@ class BarclampsController < ApplicationController
   self.cap_base = "BARCLAMP"
 
   def index
-    @list = Barclamp.all
+    @list = visible(model, cap("READ"))
     respond_to do |format|
       format.html { }
-      format.json { render api_index Barclamp, @list }
+      format.json { render api_index model, @list }
     end
   end
 
-  def upload
-    @barclamp = Barclamp.find_key params[:barclamp_id] rescue nil
-  end
-
   def show
-    @barclamp = Barclamp.find_key params[:id]
+    @barclamp = find_key_cap(model, params[:id], cap("READ"))
     respond_to do |format|
       format.html {  }
       format.json { render api_show @barclamp }
@@ -42,7 +38,9 @@ class BarclampsController < ApplicationController
     if request.patch?
       raise "PATCH update for barclamps not implemented!"
     end
-    validate_update(@current_user.current_tenant_id, "BARCLAMP", Barclamp, params[:value])
+    # Update and create are basically the same action for barclamps.
+    # Not the proper way to deal, I know, but...
+    validate_create
     @barclamp = Barclamp.import_or_update(params[:value], @current_user.current_tenant_id)
     respond_to do |format|
       format.html {  }
@@ -56,7 +54,7 @@ class BarclampsController < ApplicationController
 
   def create
     params.require(:value)
-    validate_create(@current_user.current_tenant_id, "BARCLAMP", Barclamp)
+    validate_create
     @barclamp = Barclamp.import_or_update(params[:value], @current_user.current_tenant_id)
     respond_to do |format|
       format.html {  }

--- a/rails/app/controllers/dns_name_entries_controller.rb
+++ b/rails/app/controllers/dns_name_entries_controller.rb
@@ -17,8 +17,7 @@ class DnsNameEntriesController < ::ApplicationController
   self.cap_base = "NETWORK"
 
   def show
-    @entry = DnsNameEntry.find_key params[:id]
-    validate_read(@entry.tenant_id, "NETWORK", DnsNameEntry, params[:id])
+    @entry = find_key_cap(model, params[:id], cap("READ"))
     respond_to do |format|
       format.html { }
       format.json { render api_show @entry }
@@ -26,13 +25,12 @@ class DnsNameEntriesController < ::ApplicationController
   end
 
   def index
-    tenant_ids = build_tenant_list("NETWORK_READ")
-    @entries = DnsNameEntry.where(tenant_id: tenant_ids)
-                           .includes(network_allocation: [:node])
-			   .includes(:dns_name_filter)
+    @entries = visible(model, cap("READ")).
+               includes(network_allocation: [:node]).
+	       includes(:dns_name_filter)
     respond_to do |format|
       format.html {}
-      format.json { render api_index DnsNameEntry, @entries }
+      format.json { render api_index model, @entries }
     end
   end
 

--- a/rails/app/controllers/interfaces_controller.rb
+++ b/rails/app/controllers/interfaces_controller.rb
@@ -15,6 +15,8 @@
 class InterfacesController < ::ApplicationController
   self.cap_base = "NETWORK"
 
+  # I got nothing.  We should probably turn network-server into a
+  # full-fledged database model or something.
   def create
     pattern = params[:pattern]
     bus_order = params[:bus_order].split(" | ")

--- a/rails/app/controllers/runs_controller.rb
+++ b/rails/app/controllers/runs_controller.rb
@@ -18,17 +18,17 @@ class RunsController < ApplicationController
   self.cap_base = "NODE"
 
   def index
+    @runs = visible(model,cap("READ"))
     respond_to do |format|
-      format.json { render api_index :run, Run.all }
+      format.json { render api_index model, @runs }
     end
   end
 
   # returns all the items for a node in the annealer queue
   def show
-    node = Node.find_key params[:id]
-    runs = (node.nil? ? [] : node.runs)
+    runs = find_key_cap(Node, params[:id], cap("READ")).runs
     respond_to do |format|
-      format.json { render api_index :run, runs }
+      format.json { render api_index model, runs }
     end
   end
 

--- a/rails/app/models/user.rb
+++ b/rails/app/models/user.rb
@@ -52,6 +52,7 @@ class User < ActiveRecord::Base
   scope  :admin,              -> { where(:is_admin => true) }
 
   has_many    :user_tenant_capabilities
+  has_many    :capabilities,  -> { distinct }, through: :user_tenant_capabilities
   has_many    :tenants,       -> { distinct }, through: :user_tenant_capabilities
 
   def capable(cap_name, tid)

--- a/rails/db/seeds.rb
+++ b/rails/db/seeds.rb
@@ -154,11 +154,8 @@ ActiveRecord::Base.transaction do
   u.digest_password('rebar1')
   u.save!
 
-  [ caps, dhcp_caps, dns_caps, p_caps].each do |list|
-    list.each do |c|
-      cap = Capability.find_by(name: c[0])
-      UserTenantCapability.create!(user_id: u.id, tenant_id: t.id, capability_id: cap.id)
-    end
+  Capability.all.each do |c|
+    UserTenantCapability.create!(user_id: u.id, tenant_id: t.id, capability_id: c.id)
   end
 
   if Rails.env.development? or Rails.env.test?
@@ -166,9 +163,8 @@ ActiveRecord::Base.transaction do
     u.digest_password('d1g1t@l')
     u.save!
 
-    caps.each do |c|
-      cap = Capability.find_by(name: c[0])
-      UserTenantCapability.create!(user_id: u.id, tenant_id: t.id, capability_id: cap.id)
+    Capability.all.each do |c|
+      UserTenantCapability.create!(user_id: u.id, tenant_id: t.id, capability_id: c.id)
     end
   end
 


### PR DESCRIPTION
Lots of changes here:

* The validate_* helpers have vanished, except for validate_create,
  which uses ambient model, tenant, and capability information where
  possible.

* All API endpoints in the controllers have been updated to use the
  visible and find_key_cap helpers, which push the majority of
  capability checking into the database.

* create API endpoints have been updated to perform capability checks on
  any associated objects required for that object to be created.

* Capability checking for UserTenantCapabilities have been overhauled.
  See my comments in the commit for more information.  I am open to
  persuasion for better ways to look at user capabilities.

* The visible helper on the models has been overhauled to handle more
  special cases.