### PR TITLE
retrieve provider type WITHOUT having to include credentials

### DIFF
--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -405,11 +405,11 @@ attribs:
     schema:
       type: float
   - name: provider-type
-    description: 'Provider type and name'
+    description: 'Provider type'
     map: 'provider/type'
     type: 'BarclampRebar::Attrib::ProviderType'
   - name: provider-details
-    description: 'Provider access credentials'
+    description: 'Provider access credentials, type and name'
     map: 'provider/details'
     type: 'BarclampRebar::Attrib::ProviderDetails'
 

--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -405,9 +405,13 @@ attribs:
     schema:
       type: float
   - name: provider-type
-    description: 'Provider type and access credentials'
+    description: 'Provider type and name'
     map: 'provider/type'
     type: 'BarclampRebar::Attrib::ProviderType'
+  - name: provider-details
+    description: 'Provider access credentials'
+    map: 'provider/details'
+    type: 'BarclampRebar::Attrib::ProviderDetails'
 
 providers:
   - name: phantom

--- a/rails/app/models/barclamp_rebar/attrib/provider_details.rb
+++ b/rails/app/models/barclamp_rebar/attrib/provider_details.rb
@@ -13,7 +13,7 @@
 # limitations under the License.
 #
 
-class BarclampRebar::Attrib::ProviderType < Attrib
+class BarclampRebar::Attrib::ProviderDetails < Attrib
 
   # Lookup the node's provider type
   def get(data,source=:all, committed=false)
@@ -29,8 +29,9 @@ class BarclampRebar::Attrib::ProviderType < Attrib
       end
       # no data, return
       return {} unless p
-      # make hash with info
+      # include type and name in details
       o = { type: p.class.to_s.downcase.sub("provider",""), name: p.name }
+      o.merge! p.auth_details
       return o
 
   end

--- a/rails/app/models/barclamp_rebar/attrib/provider_type.rb
+++ b/rails/app/models/barclamp_rebar/attrib/provider_type.rb
@@ -27,11 +27,7 @@ class BarclampRebar::Attrib::ProviderType < Attrib
           else
             nil
       end
-      # no data, return
-      return {} unless p
-      # make hash with info
-      o = { type: p.class.to_s.downcase.sub("provider",""), name: p.name }
-      return o
+      return p.class.to_s.downcase.sub("provider","")
 
   end
 


### PR DESCRIPTION
there are times when we don't want all of the details with the provider type
this allows roles to pick which they want.

the provider_type is JUST the type
the provider_details attrib includes the name and type.