### PR TITLE
Fix wacky provider create

### DIFF
--- a/rails/app/controllers/providers_controller.rb
+++ b/rails/app/controllers/providers_controller.rb
@@ -32,15 +32,7 @@ class ProvidersController < ApplicationController
   end
 
   def show
-    @item = if params[:id] == 'create'
-              # GREG: WTF??? Why does show create?!?!?
-              # Victor: Yes, this needs to die in a fire.
-              t = params[:new][:type]
-              validate_create
-              Provider.new(name: t.downcase, id: -1, type: t, description: I18n.t('not_set'))
-            else
-              find_key_cap(model, params[:id], cap("READ"))
-            end
+    @item = find_key_cap(model, params[:id], cap("READ"))
     respond_to do |format|
       format.html { render :show  }
       format.json { render api_show @item }

--- a/rails/app/views/providers/index.html.haml
+++ b/rails/app/views/providers/index.html.haml
@@ -5,9 +5,12 @@
     %td
       %h1= t '.title'
     %td{:align=>'right'}
-      = form_for :provider, :'data-remote' => true, :url => provider_path(:id=>"create"), :html => { :method=>:get, :'data-type' => 'html',  :class => "formtastic" } do |f|
-        = select :new, :type, options_for_select(available, available.keys.first)
-        = button_tag t(".new"), :method=>:get, :html => {:class=>"button"}
+      = form_for :provider, :'data-remote' => true, :url => providers_path(), :html => { :method=>:post, :'data-type' => 'html',  :class => "formtastic" } do |f|
+        = select_tag :type, options_for_select(available, available.keys.first)
+        = hidden_field_tag :name, I18n.t('default')+rand(1000).to_s
+        = hidden_field_tag :description, I18n.t('not_set')
+        = hidden_field_tag :auth_details, "{}"
+        %input.button{:type => "submit", :name => "create", :method=>:post, :value => t("add")}
 
 %table.data.box
   %thead


### PR DESCRIPTION
In a previous version, we tried to precreate the provider to fix that type is needed when we create the new providers and cannot be changed afterwards.

In this version, we just handle it correctly using the API.  The name has to include a random # so that we avoid collisions.  