### PR TITLE
Update validation of tenant movement or deployment movement needs to

### DIFF
--- a/rails/app/controllers/application_controller.rb
+++ b/rails/app/controllers/application_controller.rb
@@ -84,9 +84,14 @@ class ApplicationController < ActionController::Base
   end
 
   def validate_update_for(obj)
-    if (obj.previous_changes["tenant_id"] && !capable(obj.tenant_id,cap("UPDATE","TENANT"))) ||
-       (obj.previous_changes["deployment_id"] && !capable(obj.deployment_id,cap("UPDATE","DEPLOYMENT")))
+    if obj.previous_changes["tenant_id"] && !capable(obj.tenant_id,cap("UPDATE","TENANT"))
       raise RebarForbiddenError.new(obj.id,obj.class)
+    end
+    if obj.previous_changes["deployment_id"]
+      d = Deployment.find_by(id: obj.previous_changes["deployment_id"])
+      if !d.nil? && !capable(d.tenant_id,cap("UPDATE","DEPLOYMENT"))
+        raise RebarForbiddenError.new(obj.id,obj.class)
+      end
     end
   end
 


### PR DESCRIPTION
check deployment's tenant_id not the deployment id.