### PR TITLE
make sane & safe default for maps

### DIFF
--- a/rails/app/models/barclamp.rb
+++ b/rails/app/models/barclamp.rb
@@ -235,7 +235,7 @@ class Barclamp < ActiveRecord::Base
           attrib_name = attrib["name"]
           attrib_desc = attrib['description'] || ""
           attrib_ui_renderer = attrib['ui_renderer'] || Attrib::UI_RENDERER
-          attrib_map = attrib['map'] || ""
+          attrib_map = attrib['map'] || attrib_name.gsub("-","/")
           attrib_default = attrib['default']
           attrib_writable = !!attrib['schema']
           a = attrib_type.find_or_create_by!(name: attrib_name)


### PR DESCRIPTION
this is minor but it allows you to omit maps for most variables that follow the top-mid-detail naming convention.