### PR TITLE
ffi-yajl updated itself to require ruby 2.1.  This

### DIFF
--- a/script/roles/rebar-inventory/01-ohai.sh
+++ b/script/roles/rebar-inventory/01-ohai.sh
@@ -25,6 +25,7 @@ if ! which ohai; then
         if [[ $(ruby --version) =~ $matcher ]] ; then
             gem install ohai -v 7.4.1
         else
+            gem install ffi-yajl -v 2.2.3
             gem install ohai
         fi
         hash -r
@@ -34,6 +35,7 @@ if ! which ohai; then
         if [[ $(ruby --version) =~ $matcher ]] ; then
             gem install ohai -v 7.4.1
         else
+            gem install ffi-yajl -v 2.2.3
             gem install ohai
         fi
         hash -r


### PR DESCRIPTION
of course breaks all of our installs that need rebar-inventory.
That would be ALL of them.  None of the OS have ruby 2.1
by default in a repo.  This forces the installation of
ffi-yajl that works with 2.0 and meets ohai's requirements.