### PR TITLE
clear long on retry

### DIFF
--- a/rails/app/controllers/node_roles_controller.rb
+++ b/rails/app/controllers/node_roles_controller.rb
@@ -201,7 +201,7 @@ class NodeRolesController < ApplicationController
   def retry
     model.transaction do
       @node_role = find_key_cap(model, params[:id] || params[:node_role_id], cap("RETRY"))
-      @node_role.todo!
+      @node_role.todo! true
     end
     render api_show @node_role
   end


### PR DESCRIPTION
when a user asks to retry, they expect that we'll clear the log so that the node-role does not have old information.  we only want this on retry.