### PR TITLE
remove unneeded attrib

### DIFF
--- a/barclamps/rebar.yml
+++ b/barclamps/rebar.yml
@@ -31,8 +31,6 @@ wizard:
   system_nodes: true
   create_nodes: false
   os: true
-  base_attribs:
-    - provisioner-target_os
   services:
     - name: provision
       description: "Provision O/S"


### PR DESCRIPTION
the physical wizard sets this automatically, it does not need to be included