### PR TITLE
fix bug in batch with deployment scope

### DIFF
--- a/rails/app/controllers/deployments_controller.rb
+++ b/rails/app/controllers/deployments_controller.rb
@@ -172,6 +172,8 @@ class DeploymentsController < ApplicationController
   # view only
   def template
 
+    @source = find_key_cap(model, (params[:source] || 'system'), cap("READ"))
+    @provider = visible(Provider, cap("READ")).order("id DESC")
     @deployment = find_key_cap(model, params[:deployment_id], cap("PROPOSE"))
 
   end
@@ -219,6 +221,7 @@ class DeploymentsController < ApplicationController
 
     roles = {}
     deployment_roles = []
+    deployment = nil
 
     Deployment.transaction do
 

--- a/rails/app/views/deployments/template.html.haml
+++ b/rails/app/views/deployments/template.html.haml
@@ -1,4 +1,12 @@
-- data = { "provider" => { "name" => "debug-provider" }, "attribs" => {}, "nodes" => [ { "roles" => [] } ] } 
+- if @source
+  - data = { "attribs" => {}, "nodes" => [] }
+  - data["attribs"]["provisioner-target_os"] = "select o/s" #Attrib.get('provisioner-available-oses').first
+  - @source.nodes.each do |n|
+    - unless n.system?
+      - data["nodes"] << [ { "id" => n.name, "roles" => [ "rebar-installed-node" ] } ]
+- else
+  - data = { "provider" => { }, "attribs" => {}, "nodes" => [ { "roles" => [] } ] } 
+  - @provider.each { |p| data["provider"]["name"] = p.name }
 
 %table
   %tr


### PR DESCRIPTION
Also, make default template into readystate json.   Instead of just providing blank json, create something as an example that takes the place of the old ready state wizard.

TODO: 
lookup available O/S for json.
add to menu